### PR TITLE
[ENG-4484] Handle different commit action types

### DIFF
--- a/src/main/java/com/onehouse/constants/MetadataExtractorConstants.java
+++ b/src/main/java/com/onehouse/constants/MetadataExtractorConstants.java
@@ -3,6 +3,7 @@ package com.onehouse.constants;
 import com.onehouse.metadata_extractor.models.Checkpoint;
 import com.onehouse.storage.models.File;
 import java.time.Instant;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class MetadataExtractorConstants {
@@ -40,4 +41,15 @@ public class MetadataExtractorConstants {
           .isDirectory(false)
           .lastModifiedAt(Instant.EPOCH)
           .build();
+
+  public static final List<String> WHITELISTED_ACTION_TYPES =
+      List.of(
+          "commit",
+          "deltacommit",
+          "rollback",
+          "savepoint",
+          "restore",
+          "clean",
+          "compaction",
+          "replacecommit");
 }

--- a/src/main/java/com/onehouse/metadata_extractor/TimelineCommitInstantsUploader.java
+++ b/src/main/java/com/onehouse/metadata_extractor/TimelineCommitInstantsUploader.java
@@ -178,6 +178,10 @@ public class TimelineCommitInstantsUploader {
                         nextContinuationToken == null)
                     .thenComposeAsync(
                         updatedCheckpoint -> {
+                          if (updatedCheckpoint == null) {
+                            // no batches to process, returning existing checkpoint
+                            return CompletableFuture.completedFuture(checkpoint);
+                          }
                           if (StringUtils.isBlank(nextContinuationToken)) {
                             log.info(
                                 "Reached end of instants in {} for table {}",
@@ -242,6 +246,10 @@ public class TimelineCommitInstantsUploader {
       batches = activeTimelineInstantBatcher.createBatches(filesToUpload, getUploadBatchSize());
     }
     int numBatches = batches.size();
+
+    if (numBatches == 0) {
+      return CompletableFuture.completedFuture(null);
+    }
 
     log.info(
         "Processing {} instants in table {} timeline {} sequentially in {} batches",


### PR DESCRIPTION
Handle savepoint commits + exit processing when unable to create batches (in case of active timeline)