### PR TITLE
Improve 401 error message

### DIFF
--- a/src/main/java/com/onehouse/api/OnehouseApiClient.java
+++ b/src/main/java/com/onehouse/api/OnehouseApiClient.java
@@ -11,6 +11,7 @@ import static com.onehouse.constants.ApiConstants.ONEHOUSE_API_SECRET_KEY;
 import static com.onehouse.constants.ApiConstants.ONEHOUSE_REGION_KEY;
 import static com.onehouse.constants.ApiConstants.ONEHOUSE_USER_UUID_KEY;
 import static com.onehouse.constants.ApiConstants.PROJECT_UID_KEY;
+import static com.onehouse.constants.ApiConstants.UNAUTHORIZED_ERROR_MESSAGE;
 import static com.onehouse.constants.ApiConstants.UPSERT_TABLE_METRICS_CHECKPOINT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -155,7 +156,11 @@ public class OnehouseApiClient {
       try {
         T errorResponse = typeReference.getDeclaredConstructor().newInstance();
         if (errorResponse instanceof ApiResponse) {
-          ((ApiResponse) errorResponse).setError(response.code(), response.message());
+          if (response.code() == 401) {
+            ((ApiResponse) errorResponse).setError(response.code(), UNAUTHORIZED_ERROR_MESSAGE);
+          } else {
+            ((ApiResponse) errorResponse).setError(response.code(), response.message());
+          }
         }
         response.close();
         emmitApiErrorMetric(response.code());

--- a/src/main/java/com/onehouse/constants/ApiConstants.java
+++ b/src/main/java/com/onehouse/constants/ApiConstants.java
@@ -30,4 +30,7 @@ public class ApiConstants {
   // https://chromium.googlesource.com/external/github.com/grpc/grpc/+/refs/tags/v1.21.4-pre1/doc/statuscodes.md
   public static final List<Integer> ACCEPTABLE_HTTP_FAILURE_STATUS_CODES =
       Collections.unmodifiableList(new ArrayList<>(Arrays.asList(404, 400, 403, 401, 409)));
+
+  public static final String UNAUTHORIZED_ERROR_MESSAGE =
+      "Confirm that your API token is valid and has not expired.";
 }

--- a/src/main/java/com/onehouse/metadata_extractor/TableMetadataUploaderService.java
+++ b/src/main/java/com/onehouse/metadata_extractor/TableMetadataUploaderService.java
@@ -105,7 +105,7 @@ public class TableMetadataUploaderService {
             getTableMetricsCheckpointResponse -> {
               if (getTableMetricsCheckpointResponse.isFailure()) {
                 log.error(
-                    "Error encountered when fetching checkpoint, skipping table processing. status code: {} message: {}",
+                    "Error encountered when fetching checkpoint, skipping table processing. status code: {}. message: {}",
                     getTableMetricsCheckpointResponse.getStatusCode(),
                     getTableMetricsCheckpointResponse.getCause());
                 return CompletableFuture.completedFuture(false);

--- a/src/main/java/com/onehouse/metadata_extractor/TableMetadataUploaderService.java
+++ b/src/main/java/com/onehouse/metadata_extractor/TableMetadataUploaderService.java
@@ -114,8 +114,10 @@ public class TableMetadataUploaderService {
                 }
                 errorMessageBuilder.append("status code: ");
                 errorMessageBuilder.append(statusCode);
-                errorMessageBuilder.append(" message ");
-                errorMessageBuilder.append(getTableMetricsCheckpointResponse.getCause());
+                if (StringUtils.isNotBlank(getTableMetricsCheckpointResponse.getCause())) {
+                  errorMessageBuilder.append(" message: ");
+                  errorMessageBuilder.append(getTableMetricsCheckpointResponse.getCause());
+                }
                 log.error(errorMessageBuilder.toString());
                 return CompletableFuture.completedFuture(false);
               }

--- a/src/main/java/com/onehouse/metadata_extractor/TableMetadataUploaderService.java
+++ b/src/main/java/com/onehouse/metadata_extractor/TableMetadataUploaderService.java
@@ -90,8 +90,7 @@ public class TableMetadataUploaderService {
     if (StringUtils.isNotBlank(table.getTableId())) {
       return table;
     }
-    return table
-        .toBuilder()
+    return table.toBuilder()
         .tableId(getTableIdFromAbsolutePathUrl(table.getAbsoluteTableUri()).toString())
         .build();
   }
@@ -104,10 +103,19 @@ public class TableMetadataUploaderService {
         .thenComposeAsync(
             getTableMetricsCheckpointResponse -> {
               if (getTableMetricsCheckpointResponse.isFailure()) {
-                log.error(
-                    "Error encountered when fetching checkpoint, skipping table processing. status code: {} message {}",
-                    getTableMetricsCheckpointResponse.getStatusCode(),
-                    getTableMetricsCheckpointResponse.getCause());
+                int statusCode = getTableMetricsCheckpointResponse.getStatusCode();
+                StringBuilder errorMessageBuilder = new StringBuilder();
+                errorMessageBuilder.append(
+                    "Error encountered when fetching checkpoint, skipping table processing. ");
+                if (statusCode == 401) {
+                  errorMessageBuilder.append(
+                      "Confirm that your API token is valid and has not expired. ");
+                }
+                errorMessageBuilder.append("status code: ");
+                errorMessageBuilder.append(statusCode);
+                errorMessageBuilder.append(" message ");
+                errorMessageBuilder.append(getTableMetricsCheckpointResponse.getCause());
+                log.error(errorMessageBuilder.toString());
                 return CompletableFuture.completedFuture(false);
               }
 

--- a/src/main/java/com/onehouse/metadata_extractor/TableMetadataUploaderService.java
+++ b/src/main/java/com/onehouse/metadata_extractor/TableMetadataUploaderService.java
@@ -104,21 +104,10 @@ public class TableMetadataUploaderService {
         .thenComposeAsync(
             getTableMetricsCheckpointResponse -> {
               if (getTableMetricsCheckpointResponse.isFailure()) {
-                int statusCode = getTableMetricsCheckpointResponse.getStatusCode();
-                StringBuilder errorMessageBuilder = new StringBuilder();
-                errorMessageBuilder.append(
-                    "Error encountered when fetching checkpoint, skipping table processing. ");
-                if (statusCode == 401) {
-                  errorMessageBuilder.append(
-                      "Confirm that your API token is valid and has not expired. ");
-                }
-                errorMessageBuilder.append("status code: ");
-                errorMessageBuilder.append(statusCode);
-                if (StringUtils.isNotBlank(getTableMetricsCheckpointResponse.getCause())) {
-                  errorMessageBuilder.append(" message: ");
-                  errorMessageBuilder.append(getTableMetricsCheckpointResponse.getCause());
-                }
-                log.error(errorMessageBuilder.toString());
+                log.error(
+                    "Error encountered when fetching checkpoint, skipping table processing. status code: {} message: {}",
+                    getTableMetricsCheckpointResponse.getStatusCode(),
+                    getTableMetricsCheckpointResponse.getCause());
                 return CompletableFuture.completedFuture(false);
               }
 

--- a/src/main/java/com/onehouse/metadata_extractor/TableMetadataUploaderService.java
+++ b/src/main/java/com/onehouse/metadata_extractor/TableMetadataUploaderService.java
@@ -90,7 +90,8 @@ public class TableMetadataUploaderService {
     if (StringUtils.isNotBlank(table.getTableId())) {
       return table;
     }
-    return table.toBuilder()
+    return table
+        .toBuilder()
         .tableId(getTableIdFromAbsolutePathUrl(table.getAbsoluteTableUri()).toString())
         .build();
   }

--- a/src/test/java/com/onehouse/api/OnehouseApiClientTest.java
+++ b/src/test/java/com/onehouse/api/OnehouseApiClientTest.java
@@ -10,6 +10,7 @@ import static com.onehouse.constants.ApiConstants.ONEHOUSE_API_SECRET_KEY;
 import static com.onehouse.constants.ApiConstants.ONEHOUSE_REGION_KEY;
 import static com.onehouse.constants.ApiConstants.ONEHOUSE_USER_UUID_KEY;
 import static com.onehouse.constants.ApiConstants.PROJECT_UID_KEY;
+import static com.onehouse.constants.ApiConstants.UNAUTHORIZED_ERROR_MESSAGE;
 import static com.onehouse.constants.ApiConstants.UPSERT_TABLE_METRICS_CHECKPOINT;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -66,6 +67,7 @@ class OnehouseApiClientTest {
   private OnehouseApiClient onehouseApiClient;
 
   private static final int FAILURE_STATUS_CODE_USER = 400;
+  private static final int FAILURE_STATUS_CODE_UNAUTHORIZED = 401;
   private static final int FAILURE_STATUS_CODE_SYSTEM = 500;
   private static final String SAMPLE_HOST = "http://example.com";
   private static final String FAILURE_ERROR = "call failed";
@@ -135,7 +137,12 @@ class OnehouseApiClientTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {FAILURE_STATUS_CODE_SYSTEM, FAILURE_STATUS_CODE_USER})
+  @ValueSource(
+      ints = {
+        FAILURE_STATUS_CODE_SYSTEM,
+        FAILURE_STATUS_CODE_USER,
+        FAILURE_STATUS_CODE_UNAUTHORIZED
+      })
   void testAsyncPostFailure(int failureStatusCode) {
     String apiEndpoint = "/testEndpoint";
     String requestJson = "{\"key\":\"value\"}";
@@ -151,6 +158,9 @@ class OnehouseApiClientTest {
                 ? MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR
                 : MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR);
     assertEquals(failureStatusCode, result.getStatusCode());
+    if (failureStatusCode == FAILURE_STATUS_CODE_UNAUTHORIZED) {
+      assertEquals(UNAUTHORIZED_ERROR_MESSAGE, result.getCause());
+    }
   }
 
   @Test
@@ -165,7 +175,12 @@ class OnehouseApiClientTest {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {FAILURE_STATUS_CODE_SYSTEM, FAILURE_STATUS_CODE_USER})
+  @ValueSource(
+      ints = {
+        FAILURE_STATUS_CODE_SYSTEM,
+        FAILURE_STATUS_CODE_USER,
+        FAILURE_STATUS_CODE_UNAUTHORIZED
+      })
   void testAsyncGetFailure(int failureStatusCode) {
     String apiEndpoint = "/testEndpoint";
     stubOkHttpCall(apiEndpoint, true, failureStatusCode);
@@ -180,6 +195,9 @@ class OnehouseApiClientTest {
                 ? MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR
                 : MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR);
     assertEquals(failureStatusCode, result.getStatusCode());
+    if (failureStatusCode == FAILURE_STATUS_CODE_UNAUTHORIZED) {
+      assertEquals(UNAUTHORIZED_ERROR_MESSAGE, result.getCause());
+    }
   }
 
   static Stream<Arguments> provideInitializeTableMetricsCheckpointValue() {


### PR DESCRIPTION
401 error message is usually due to invalid or expired Onehouse API token. Improve error message to help users debug the issue.

Manually tested by specifying a wrong api secret and ran the jar locally. Then I see below logs
```
17:20:18.955 [metadata-extractor-2] INFO  c.o.m.TableDiscoveryService - Discovering tables in s3://acme-lake/acme/acme_default/1clickstream_event/v1/
17:20:19.001 [metadata-extractor-1] INFO  c.o.m.TableMetadataUploaderService - Uploading metadata of following tables: [Table(absoluteTableUri=s3://acme-lake/acme/acme_default/1clickstream_event/v1/, databaseName=daniel-database, lakeName=daniel-lake, tableId=null)]
17:20:19.003 [metadata-extractor-1] INFO  c.o.m.TableMetadataUploaderService - Fetching checkpoint for tables: [Table(absoluteTableUri=s3://acme-lake/acme/acme_default/1clickstream_event/v1/, databaseName=daniel-database, lakeName=daniel-lake, tableId=11a9bb56-9002-346f-8dc3-01e75fddb382)]
17:20:19.139 [metadata-extractor-1] ERROR c.o.m.TableMetadataUploaderService - Error encountered when fetching checkpoint, skipping table processing. status code: 401. message: Confirm that your API token is valid and has not expired.
```