### PR TITLE
[ENG-11936] Start metrics server only when scraping is configured

### DIFF
--- a/src/main/java/com/onehouse/constants/MetricsConstants.java
+++ b/src/main/java/com/onehouse/constants/MetricsConstants.java
@@ -1,8 +1,13 @@
 package com.onehouse.constants;
 
 public class MetricsConstants {
+  public static final int PROMETHEUS_METRICS_SCRAPING_DISABLED = 0;
   public static final int PROMETHEUS_METRICS_SCRAPE_PORT =
-      Integer.parseInt(System.getenv().getOrDefault("PROMETHEUS_METRICS_SCRAPE_PORT", "7070"));
+      Integer.parseInt(
+          System.getenv()
+              .getOrDefault(
+                  "PROMETHEUS_METRICS_SCRAPE_PORT",
+                  String.valueOf(PROMETHEUS_METRICS_SCRAPING_DISABLED)));
 
   public enum MetadataUploadFailureReasons {
     API_FAILURE_USER_ERROR,

--- a/src/main/java/com/onehouse/metrics/MetricsServer.java
+++ b/src/main/java/com/onehouse/metrics/MetricsServer.java
@@ -1,5 +1,7 @@
 package com.onehouse.metrics;
 
+import static com.onehouse.constants.MetricsConstants.PROMETHEUS_METRICS_SCRAPING_DISABLED;
+
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.HTTPServer;
 import java.io.IOException;
@@ -11,12 +13,16 @@ public class MetricsServer {
   private final HTTPServer server;
 
   public MetricsServer(CollectorRegistry registry, int port) {
-    try {
-      log.info("Starting metrics server");
-      server = initHttpServer(new InetSocketAddress(port), registry);
-      Runtime.getRuntime().addShutdownHook(new Thread(server::close));
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to start metrics server", e);
+    if (port != PROMETHEUS_METRICS_SCRAPING_DISABLED) {
+      try {
+        log.info("Starting metrics server");
+        server = initHttpServer(new InetSocketAddress(port), registry);
+        Runtime.getRuntime().addShutdownHook(new Thread(server::close));
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to start metrics server", e);
+      }
+    } else {
+      server = null;
     }
   }
 

--- a/src/test/java/com/onehouse/metrics/MetricsServerTest.java
+++ b/src/test/java/com/onehouse/metrics/MetricsServerTest.java
@@ -1,5 +1,6 @@
 package com.onehouse.metrics;
 
+import static com.onehouse.constants.MetricsConstants.PROMETHEUS_METRICS_SCRAPING_DISABLED;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -54,6 +55,17 @@ class MetricsServerTest {
       metricsServer.shutdown();
 
       verify(httpServer).close();
+    }
+  }
+
+  @Test
+  @SneakyThrows
+  void testMetricsServerInitWhenScrapingIsNotConfigured() {
+    try (MockedStatic<MetricsServer> mocked = mockStatic(MetricsServer.class)) {
+      MetricsServer metricsServer =
+          new MetricsServer(registry, PROMETHEUS_METRICS_SCRAPING_DISABLED);
+      metricsServer.shutdown();
+      mocked.verify(() -> MetricsServer.initHttpServer(any(), any()), times(0));
     }
   }
 }


### PR DESCRIPTION
currently we are seeing a dependency issue when trying to start metrics server on glue, the fix for this will be taken up some other time.

tested on glue, the extractor was running (failures messages are because the api keys have expired, this can be ignored)
<img width="1701" alt="image" src="https://github.com/user-attachments/assets/5d80d644-bbe2-4868-a5d0-d9ad1577367d">
