### PR TITLE
[ENG-14936] Added logic to publish jars via gradle to maven central

### DIFF
--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -41,6 +41,11 @@ jobs:
         env:
           SONARTYPE_USERNAME: ${{ secrets.SONARTYPE_USERNAME }}
           SONARTYPE_USER_TOKEN: ${{ secrets.SONARTYPE_USER_TOKEN }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.SONARTYPE_USERNAME }}
+          JRELEASER_MAVENCENTRAL_TOKEN: ${{ secrets.SONARTYPE_USER_TOKEN }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           if [[ "$branch_name" == "release-v"* ]]; then
@@ -51,6 +56,7 @@ jobs:
             echo "Publishing snapshot release"
             ./gradlew publish -Pversion="0.0.${{ github.event.pull_request.number }}-SNAPSHOT"
           fi
+          ./gradlew jreleaserFullRelease
 
       - name: Upload lakeview jar file to Release
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -39,24 +39,25 @@ jobs:
 
       - name: Publish with Gradle
         env:
-          SONARTYPE_USERNAME: ${{ secrets.SONARTYPE_USERNAME }}
-          SONARTYPE_USER_TOKEN: ${{ secrets.SONARTYPE_USER_TOKEN }}
-          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
-          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
-          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.SONARTYPE_USERNAME }}
-          JRELEASER_MAVENCENTRAL_TOKEN: ${{ secrets.SONARTYPE_USER_TOKEN }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVENCENTRAL_AUTH_HEADER: ${{ secrets.MAVENCENTRAL_AUTH_HEADER }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           if [[ "$branch_name" == "release-v"* ]]; then
             version_number=${branch_name:9}
             echo "Publishing release branch"
             ./gradlew publish -PbuildRelease=true -Pversion=${version_number}
-          else
-            echo "Publishing snapshot release"
-            ./gradlew publish -Pversion="0.0.${{ github.event.pull_request.number }}-SNAPSHOT"
+            cd lakeview/build/staging-deploy/
+            zip -r ai.onehouse-lakeview-${version_number}.zip .
+            curl --request POST \
+              --verbose \
+              --header 'Authorization: Bearer ${{ secrets.MAVENCENTRAL_AUTH_HEADER }}' \
+              --form bundle=@ai.onehouse-lakeview-${version_number}.zip \
+              https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC
+            cd ../../../
           fi
-          ./gradlew jreleaserFullRelease
 
       - name: Upload lakeview jar file to Release
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -37,16 +37,6 @@ jobs:
       - name: Set input tag
         run: echo "INPUT_TAG=${{ inputs.tags }}" >> $GITHUB_ENV
 
-      - name: Upload JAR files to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: lakeview/build/libs/LakeView-1.0-SNAPSHOT-all.jar
-          asset_name: LakeView-${{ env.INPUT_TAG }}-all.jar
-          asset_content_type: application/java-archive
-
       - name: Publish with Gradle
         env:
           USERNAME_PUBLISH_LAKEVIEW_JARS: nimahajan
@@ -62,7 +52,17 @@ jobs:
             ./gradlew publish
           fi
 
-      - name: Upload JAR files to Release
+      - name: Upload lakeview jar file to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: lakeview/build/libs/LakeView-1.0-SNAPSHOT-all.jar
+          asset_name: LakeView-${{ env.INPUT_TAG }}-all.jar
+          asset_content_type: application/java-archive
+
+      - name: Upload lakeview source jar file to Release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
           asset_name: LakeView-${{ env.INPUT_TAG }}-sources.jar
           asset_content_type: application/java-archive
 
-      - name: Upload JAR files to Release
+      - name: Upload lakeview-glue jar file to Release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
           asset_name: lakeview-glue-${{ env.INPUT_TAG }}-all.jar
           asset_content_type: application/java-archive
 
-      - name: Upload JAR files to Release
+      - name: Upload lakeview-glue source jar file to Release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -49,7 +49,7 @@ jobs:
             ./gradlew publish -PbuildRelease=true -Pversion=${version_number}
           else
             echo "Publishing snapshot release"
-            ./gradlew publish -Pversion="0.0.${{ github.run_number }}-SNAPSHOT"
+            ./gradlew publish -Pversion="0.0.${{ github.event.number }}-SNAPSHOT"
           fi
 
       - name: Upload lakeview jar file to Release

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Publish with Gradle
         env:
-          USERNAME_PUBLISH_LAKEVIEW_JARS: nimahajan
+          USERNAME_PUBLISH_LAKEVIEW_JARS: ${{ github.actor }}
           PAT_PUBLISH_LAKEVIEW_JARS: ${{ secrets.GITHUB_TOKEN }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Publish with Gradle
         env:
-          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_USER_TOKEN: ${{ secrets.SONATYPE_USER_TOKEN }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           if [[ "$branch_name" == "release-v"* ]]; then

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -47,6 +47,21 @@ jobs:
           asset_name: LakeView-${{ env.INPUT_TAG }}-all.jar
           asset_content_type: application/java-archive
 
+      - name: Publish with Gradle
+        env:
+          USERNAME_PUBLISH_LAKEVIEW_JARS: nimahajan
+          PAT_PUBLISH_LAKEVIEW_JARS: ${{ secrets.PAT_PUBLISH_LAKEVIEW_JARS }}
+        run: |
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          if [[ "$branch_name" == "release-v"* ]]; then
+            version_number=${branch_name:9}
+            echo "Publishing release branch"
+            ./gradlew publish -PbuildRelease=true -Pversion=${version_number}
+          else
+            echo "Publishing snapshot release"
+            ./gradlew publish
+          fi
+
       - name: Upload JAR files to Release
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -49,7 +49,7 @@ jobs:
             ./gradlew publish -PbuildRelease=true -Pversion=${version_number}
           else
             echo "Publishing snapshot release"
-            ./gradlew publish -Pversion="0.0.${{ github.event.number }}-SNAPSHOT"
+            ./gradlew publish -Pversion="0.0.${{ github.event.pull_request.number }}-SNAPSHOT"
           fi
 
       - name: Upload lakeview jar file to Release

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Publish with Gradle
         env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           if [[ "$branch_name" == "release-v"* ]]; then

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Publish with Gradle
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_USER_TOKEN: ${{ secrets.SONATYPE_USER_TOKEN }}
+          SONARTYPE_USERNAME: ${{ secrets.SONARTYPE_USERNAME }}
+          SONARTYPE_USER_TOKEN: ${{ secrets.SONARTYPE_USER_TOKEN }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           if [[ "$branch_name" == "release-v"* ]]; then

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Publish with Gradle
         env:
-          USERNAME_PUBLISH_LAKEVIEW_JARS: ${{ github.actor }}
-          PAT_PUBLISH_LAKEVIEW_JARS: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           if [[ "$branch_name" == "release-v"* ]]; then

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -49,7 +49,7 @@ jobs:
             ./gradlew publish -PbuildRelease=true -Pversion=${version_number}
           else
             echo "Publishing snapshot release"
-            ./gradlew publish
+            ./gradlew publish -Pversion="0.0.${{ github.run_number }}-SNAPSHOT"
           fi
 
       - name: Upload lakeview jar file to Release

--- a/.github/workflows/build-jar.yaml
+++ b/.github/workflows/build-jar.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Publish with Gradle
         env:
           USERNAME_PUBLISH_LAKEVIEW_JARS: nimahajan
-          PAT_PUBLISH_LAKEVIEW_JARS: ${{ secrets.PAT_PUBLISH_LAKEVIEW_JARS }}
+          PAT_PUBLISH_LAKEVIEW_JARS: ${{ secrets.GITHUB_TOKEN }}
         run: |
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           if [[ "$branch_name" == "release-v"* ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ bin/
 
 Library
 .java-version
+
+# signature files
+*.asc

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ subprojects {
                 name = "GitHubPackages"
                 url = uri("https://maven.pkg.github.com/onehouseinc/LakeView")
                 credentials {
-                    username = System.getenv("USERNAME_PUBLISH_LAKEVIEW_JARS")
+                    username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
                     password = System.getenv("PAT_PUBLISH_LAKEVIEW_JARS")
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ subprojects {
     publishing {
         repositories {
             maven {
+                name =  "OSSRH"
                 url = project.hasProperty('buildRelease') ?
                         "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/" :
                         "https://s01.oss.sonatype.org/content/repositories/snapshots/"

--- a/build.gradle
+++ b/build.gradle
@@ -132,8 +132,8 @@ subprojects {
                         "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/" :
                         "https://s01.oss.sonatype.org/content/repositories/snapshots/"
                 credentials {
-                    username = System.getenv("SONATYPE_USERNAME")
-                    password = System.getenv("SONATYPE_USER_TOKEN")
+                    username = System.getenv("SONARTYPE_USERNAME")
+                    password = System.getenv("SONARTYPE_USER_TOKEN")
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ subprojects {
         }
         publications {
             mavenJava(MavenPublication) {
-                groupId project.group
+                groupId 'ai.onehouse'
                 artifactId project.name
                 version = project.version
             }

--- a/build.gradle
+++ b/build.gradle
@@ -131,8 +131,8 @@ subprojects {
                         "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/" :
                         "https://s01.oss.sonatype.org/content/repositories/snapshots/"
                 credentials {
-                    username = System.getenv("SONATYPE_USER")
-                    password = System.getenv("SONATYPE_PASSWORD")
+                    username = System.getenv("SONATYPE_USERNAME")
+                    password = System.getenv("SONATYPE_USER_TOKEN")
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -118,19 +118,25 @@ subprojects {
         from sourceSets.main.allSource
     }
 
+    artifacts {
+        archives sourceJar
+    }
+
     build.dependsOn sourceJar
 
     publishing {
         repositories {
             maven {
-                name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/onehouseinc/LakeView")
+                url = project.hasProperty('buildRelease') ?
+                        "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/" :
+                        "https://s01.oss.sonatype.org/content/repositories/snapshots/"
                 credentials {
-                    username = System.getenv("GITHUB_ACTOR")
-                    password = System.getenv("GITHUB_TOKEN")
+                    username = System.getenv("SONATYPE_USER")
+                    password = System.getenv("SONATYPE_PASSWORD")
                 }
             }
         }
+
         publications {
             mavenJava(MavenPublication) {
                 groupId 'ai.onehouse'
@@ -138,6 +144,25 @@ subprojects {
                 version = project.version
 
                 from components.java
+
+                pom {
+                    name.set("LakeView")
+                    description.set("LakeView is a free product provided by Onehouse for the Apache Hudi community. LakeView exposes an interactive interface with pre-built metrics, charts, and alerts to help you monitor, optimize, and debug your data lakehouse tables.")
+                    url.set("https://www.onehouse.ai/product/lakeview")
+                    licenses {
+                        license {
+                            name.set("Apache-2.0")
+                            distribution.set("repo")
+                            url.set("https://github.com/onehouseinc/LakeView/blob/main/LICENSE.txt")
+                        }
+                    }
+
+                    scm {
+                        connection.set("scm:git:ssh://github.com/onehouseinc/LakeView.git")
+                        developerConnection.set("scm:git:ssh://github.com/onehouseinc/LakeView.git")
+                        url.set("https://github.com/onehouseinc/LakeView")
+                    }
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,8 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0'
     id 'com.github.johnrengelman.shadow' version '7.1.0'
     id 'org.sonarqube' version '4.0.0.2929'
-    id 'org.jreleaser' version '1.13.1'
+    id 'signing'
+    id 'org.jreleaser' version '1.14.0'
 }
 
 spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0'
     id 'com.github.johnrengelman.shadow' version '7.1.0'
     id 'org.sonarqube' version '4.0.0.2929'
+    id 'org.jreleaser' version '1.13.1'
 }
 
 spotless {
@@ -106,6 +107,7 @@ subprojects {
     apply plugin: 'io.freefair.lombok'
     apply plugin: 'com.diffplug.spotless'
     apply plugin: "maven-publish"
+    apply plugin: 'org.jreleaser'
 
     compileJava {
         options.compilerArgs << '-Xlint:unchecked'
@@ -127,14 +129,7 @@ subprojects {
     publishing {
         repositories {
             maven {
-                name =  "OSSRH"
-                url = project.hasProperty('buildRelease') ?
-                        "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/" :
-                        "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-                credentials {
-                    username = System.getenv("SONARTYPE_USERNAME")
-                    password = System.getenv("SONARTYPE_USER_TOKEN")
-                }
+                url = layout.buildDirectory.dir('staging-deploy')
             }
         }
 
@@ -162,6 +157,24 @@ subprojects {
                         connection.set("scm:git:ssh://github.com/onehouseinc/LakeView.git")
                         developerConnection.set("scm:git:ssh://github.com/onehouseinc/LakeView.git")
                         url.set("https://github.com/onehouseinc/LakeView")
+                    }
+                }
+            }
+        }
+    }
+
+    jreleaser {
+        signing {
+            active = 'ALWAYS'
+            armored = true
+        }
+        deploy {
+            maven {
+                mavenCentral {
+                    sonatype {
+                        active = 'ALWAYS'
+                        url = 'https://central.sonatype.com/api/v1/publisher'
+                        stagingRepository('build/staging-deploy')
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ tasks.getByPath('sonar').setDependsOn([])
 tasks.getByPath('sonar').setMustRunAfter([])
 
 group = 'ai.onehouse'
-version = '1.0-SNAPSHOT'
+version = project.hasProperty('version') ? project.version : '1.0-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -105,6 +105,7 @@ subprojects {
     apply plugin: 'application'
     apply plugin: 'io.freefair.lombok'
     apply plugin: 'com.diffplug.spotless'
+    apply plugin: "maven-publish"
 
     compileJava {
         options.compilerArgs << '-Xlint:unchecked'
@@ -118,6 +119,25 @@ subprojects {
     }
 
     build.dependsOn sourceJar
+
+    publishing {
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/onehouseinc/LakeView")
+                credentials {
+                    username = System.getenv("USERNAME_PUBLISH_LAKEVIEW_JARS")
+                    password = System.getenv("PAT_PUBLISH_LAKEVIEW_JARS")
+                }
+            }
+        }
+        publications {
+            gpr(MavenPublication) {
+                from(components.java)
+
+            }
+        }
+    }
 }
 
 // Configure Shadow plugin

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ sonar {
             property "sonar.pullrequest.key", project.getProperty("pullrequest_key")
             property "sonar.pullrequest.branch", project.getProperty("pullrequest_branch")
             property "sonar.pullrequest.base", project.getProperty("pullrequest_base")
-            property "sonar.pullrequest.github.repository", "https://github.com/onehouseinc/gateway-controller"
+            property "sonar.pullrequest.github.repository", "https://github.com/onehouseinc/LakeView"
         } else {
             property "sonar.branch.name", project.getProperty("branch_name")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,8 @@ subprojects {
                 groupId 'ai.onehouse'
                 artifactId project.name
                 version = project.version
+
+                from components.java
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -132,9 +132,10 @@ subprojects {
             }
         }
         publications {
-            gpr(MavenPublication) {
-                from(components.java)
-
+            mavenJava(MavenPublication) {
+                groupId project.group
+                artifactId project.name
+                version = project.version
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.0'
     id 'org.sonarqube' version '4.0.0.2929'
     id 'signing'
-    id 'org.jreleaser' version '1.14.0'
 }
 
 spotless {
@@ -108,11 +107,15 @@ subprojects {
     apply plugin: 'io.freefair.lombok'
     apply plugin: 'com.diffplug.spotless'
     apply plugin: "maven-publish"
-    apply plugin: 'org.jreleaser'
 
     compileJava {
         options.compilerArgs << '-Xlint:unchecked'
         options.compilerArgs << '-Xlint:-deprecation'
+    }
+
+    java {
+        withJavadocJar()
+        withSourcesJar()
     }
 
     // other shadow jar config
@@ -159,27 +162,26 @@ subprojects {
                         developerConnection.set("scm:git:ssh://github.com/onehouseinc/LakeView.git")
                         url.set("https://github.com/onehouseinc/LakeView")
                     }
+
+                    developers {
+                        developer {
+                            id = 'pkgajulapalli'
+                            name = 'Praveen Gajulapalli'
+                            email = 'praveeng@onehouse.ai'
+                        }
+                    }
                 }
             }
         }
     }
 
-    jreleaser {
-        signing {
-            active = 'ALWAYS'
-            armored = true
-        }
-        deploy {
-            maven {
-                mavenCentral {
-                    sonatype {
-                        active = 'ALWAYS'
-                        url = 'https://central.sonatype.com/api/v1/publisher'
-                        stagingRepository('build/staging-deploy')
-                    }
-                }
-            }
-        }
+    generateMetadataFileForMavenJavaPublication.dependsOn sourceJar
+    generateMetadataFileForMavenJavaPublication.dependsOn javadocJar
+
+    signing {
+        // Automatically sign all publications
+        useInMemoryPgpKeys(System.getenv("GPG_KEY_ID"), System.getenv("GPG_SECRET_KEY"), System.getenv("GPG_PASSPHRASE"))
+        sign publishing.publications.mavenJava
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -126,8 +126,8 @@ subprojects {
                 name = "GitHubPackages"
                 url = uri("https://maven.pkg.github.com/onehouseinc/LakeView")
                 credentials {
-                    username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
-                    password = System.getenv("PAT_PUBLISH_LAKEVIEW_JARS")
+                    username = System.getenv("GITHUB_ACTOR")
+                    password = System.getenv("GITHUB_TOKEN")
                 }
             }
         }

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploader.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploader.java
@@ -90,7 +90,7 @@ public class TimelineCommitInstantsUploader {
    * @param table The table object.
    * @param checkpoint Checkpoint object used to track already processed instants.
    * @param commitTimelineType Type of the commit timeline.
-   * @return CompletableFuture<Checkpoint> A future that completes with a new checkpoint after the
+   * @return A future that completes with a new checkpoint after the
    *     upload is finished.
    */
   public CompletableFuture<Checkpoint> batchUploadWithCheckpoint(
@@ -115,7 +115,7 @@ public class TimelineCommitInstantsUploader {
    * @param table The table object.
    * @param checkpoint Checkpoint object used to track already processed instants.
    * @param commitTimelineType Type of the commit timeline.
-   * @return CompletableFuture<Checkpoint> A future that completes with a new checkpoint after each
+   * @return A future that completes with a new checkpoint after each
    *     paginated upload.
    */
   public CompletableFuture<Checkpoint> paginatedBatchUploadWithCheckpoint(


### PR DESCRIPTION
**High level changes:**

1. Added `signing` plugin in add signature to artifacts.
2. Generate javadocs jar files
3. Include sources, javadocs in published artifacts.
4. Use Publisher API from cental-sonartype to upload the artifact.
5. Published the signature used with following command.
````
gpg --keyserver keyserver.ubuntu.com --send-keys PUBLIC_KEY
````