### PR TITLE
[ENG-15363] Fix for continue on incomplete commit approach

### DIFF
--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcher.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcher.java
@@ -9,6 +9,7 @@ import ai.onehouse.config.Config;
 import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.metadata_extractor.models.Checkpoint;
 import ai.onehouse.storage.models.File;
+import com.google.cloud.Tuple;
 import com.google.inject.Inject;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -24,6 +25,7 @@ import lombok.Builder;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 
 public class ActiveTimelineInstantBatcher {
   private final MetadataExtractorConfig extractorConfig;
@@ -40,7 +42,7 @@ public class ActiveTimelineInstantBatcher {
    * @param maxBatchSize the maximum number of instants per batch.
    * @return A list of batches, each batch being a list of instants.
    */
-  public Pair<String, List<List<File>>> createBatches(
+  public Triple<String, List<List<File>>, String> createBatches(
       List<File> instants, int maxBatchSize, Checkpoint checkpoint) {
     if (maxBatchSize < 3) {
       throw new IllegalArgumentException("max batch size cannot be less than 3");
@@ -61,6 +63,7 @@ public class ActiveTimelineInstantBatcher {
     List<List<File>> batches = new ArrayList<>();
     List<File> currentBatch = new ArrayList<>();
     String firstIncompleteCheckpoint = checkpoint.getFirstIncompleteCommitFile();
+    String lastUnprocessedFile = "";
 
     int startIndex = 0;
     if (!sortedInstants.isEmpty()
@@ -90,6 +93,7 @@ public class ActiveTimelineInstantBatcher {
           // metrics.
           areInstantsInGrpRelated = false;
           shouldStopIteration = true;
+          lastUnprocessedFile = instant1.getTimestamp();
         } else {
           ActiveTimelineInstant instant2 =
               getActiveTimeLineInstant(sortedInstants.get(index + 1).getFilename());
@@ -106,6 +110,7 @@ public class ActiveTimelineInstantBatcher {
           // If the latest commit is not complete
           areInstantsInGrpRelated = false;
           shouldStopIteration = true;
+          lastUnprocessedFile = instant1.getTimestamp();
         } else {
           ActiveTimelineInstant instant2 =
               getActiveTimeLineInstant(sortedInstants.get(index + 1).getFilename());
@@ -117,6 +122,7 @@ public class ActiveTimelineInstantBatcher {
           // If the latest commit is not complete
           areInstantsInGrpRelated = false;
           shouldStopIteration = true;
+          lastUnprocessedFile = instant1.getTimestamp();
         } else {
           ActiveTimelineInstant instant2 =
               getActiveTimeLineInstant(sortedInstants.get(index + 1).getFilename());
@@ -152,6 +158,7 @@ public class ActiveTimelineInstantBatcher {
           groupSize = 1;
         } else {
           shouldStopIteration = true;
+          lastUnprocessedFile = instant1.getTimestamp();
         }
       }
 
@@ -171,13 +178,20 @@ public class ActiveTimelineInstantBatcher {
       batches.add(currentBatch);
     }
 
-    return Pair.of(firstIncompleteCheckpoint, batches);
+
+    return Triple.of(firstIncompleteCheckpoint, batches, getFirstIncompleteCheckpoint(lastUnprocessedFile));
   }
 
-  private static String getFirstIncompleteCheckpoint(String numericString) {
-    BigInteger number = new BigInteger(numericString);
-    BigInteger decrementedNumber = number.subtract(BigInteger.ONE);
-    return decrementedNumber.toString();
+  public static String getFirstIncompleteCheckpoint(String numericString) {
+    try {
+      BigInteger number = new BigInteger(numericString);
+      BigInteger decrementedNumber = number.subtract(BigInteger.ONE);
+      return decrementedNumber.toString();
+    } catch (NumberFormatException ex) {
+      System.out.println("test");
+      return "";
+    }
+
   }
 
   private List<File> sortAndFilterInstants(List<File> instants) {
@@ -208,7 +222,7 @@ public class ActiveTimelineInstantBatcher {
   private boolean filterFile(File file) {
     return file.getFilename().equals(HOODIE_PROPERTIES_FILE)
         || WHITELISTED_ACTION_TYPES.contains(
-            getActiveTimeLineInstant(file.getFilename()).getAction());
+        getActiveTimeLineInstant(file.getFilename()).getAction());
   }
 
   private Comparator<File> getFileComparator() {
@@ -250,7 +264,7 @@ public class ActiveTimelineInstantBatcher {
     return states.containsAll(Arrays.asList("inflight", "completed"));
   }
 
-  private static ActiveTimelineInstant getActiveTimeLineInstant(String instant) {
+  public static ActiveTimelineInstant getActiveTimeLineInstant(String instant) {
     String[] parts = instant.split("\\.", 3);
 
     String action;
@@ -268,7 +282,7 @@ public class ActiveTimelineInstantBatcher {
 
   @Builder
   @Getter
-  private static class ActiveTimelineInstant {
+  public static class ActiveTimelineInstant {
     private final String timestamp;
     private final String action;
     private final String state;

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcherTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcherTest.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 import ai.onehouse.metadata_extractor.models.Checkpoint;
 import ai.onehouse.storage.models.File;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -64,7 +65,7 @@ class ActiveTimelineInstantBatcherTest {
         Arrays.asList(Collections.singletonList(generateFileObj("hoodie.properties")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -82,7 +83,7 @@ class ActiveTimelineInstantBatcherTest {
         Arrays.asList(Collections.singletonList(generateFileObj("hoodie.properties")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -118,7 +119,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("333.clean.requested")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -151,7 +152,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("222.compaction.requested")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -180,7 +181,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("222.savepoint"), generateFileObj("222.savepoint.inflight")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -211,7 +212,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("222.clean.requested")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -245,7 +246,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("222.clean.requested")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -279,7 +280,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("222.clean.requested")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -313,7 +314,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("555.rollback.requested")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -347,7 +348,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("444.savepoint"), generateFileObj("444.savepoint.inflight")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -381,7 +382,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("555.inflight")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -414,7 +415,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("333.clean.requested")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -444,7 +445,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("333.clean.requested")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -468,7 +469,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("111.inflight")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -491,7 +492,7 @@ class ActiveTimelineInstantBatcherTest {
                 generateFileObj("111.inflight")));
 
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -513,7 +514,7 @@ class ActiveTimelineInstantBatcherTest {
   @MethodSource("createBatchTestCases")
   void testCreateBatchJustHoodieProperties(List<File> instants, List<List<File>> expectedBatches) {
     List<List<File>> actualBatches =
-        activeTimelineInstantBatcher.createBatches(instants, 4, getCheckpoint()).getRight();
+        activeTimelineInstantBatcher.createBatches(instants, 4, getCheckpoint()).getMiddle();
     assertEquals(expectedBatches, actualBatches);
   }
 
@@ -534,9 +535,9 @@ class ActiveTimelineInstantBatcherTest {
       List<List<File>> expectedBatches,
       Checkpoint inputCheckpoint,
       String expectedFirstIncompleteCommit) {
-    Pair<String, List<List<File>>> incompleteCommitBatchesPair =
+    Triple<String, List<List<File>>, String> incompleteCommitBatchesPair =
         activeTimelineInstantBatcher.createBatches(inputFiles, 4, inputCheckpoint);
-    assertEquals(expectedBatches, incompleteCommitBatchesPair.getRight());
+    assertEquals(expectedBatches, incompleteCommitBatchesPair.getMiddle());
     assertEquals(expectedFirstIncompleteCommit, incompleteCommitBatchesPair.getLeft());
   }
 

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploaderTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploaderTest.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -117,6 +118,7 @@ class TimelineCommitInstantsUploaderTest {
     timelineCommitInstantsUploader = getTimelineCommitInstantsUploader(testInfo);
   }
 
+  @Tag("Blocking")
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testUploadInstantsInArchivedTimeline(boolean continueFromCheckpoint) {
@@ -583,6 +585,7 @@ class TimelineCommitInstantsUploaderTest {
         Arguments.of(false, true));
   }
 
+  @Tag("Blocking")
   @Test
   void testUploadInstantsInEmptyActiveTimelineWhenArchivedTimelineNotPresent() {
     TimelineCommitInstantsUploader timelineCommitInstantsUploaderSpy =
@@ -644,6 +647,7 @@ class TimelineCommitInstantsUploaderTest {
     assertEquals(checkpoint1, response);
   }
 
+  @Tag("Blocking")
   @Test
   void testUploadInstantsInActiveTimelineWithOnlySavepoint() {
     TimelineCommitInstantsUploader timelineCommitInstantsUploaderSpy =
@@ -870,6 +874,7 @@ class TimelineCommitInstantsUploaderTest {
             MetricsConstants.MetadataUploadFailureReasons.UNKNOWN);
   }
 
+  @Tag("Blocking")
   @Test
   @SneakyThrows
   void testUploadInstantFailureWhenUpdatingCheckpoint() {
@@ -1116,7 +1121,7 @@ class TimelineCommitInstantsUploaderTest {
                     }))
             .collect(Collectors.toList());
     when(activeTimelineInstantBatcher.createBatches(sortedFiles, 4, inputCheckpoint))
-        .thenReturn(Pair.of(firstIncompleteCommit, expectedBatches));
+        .thenReturn(Triple.of(firstIncompleteCommit, expectedBatches, ""));
   }
 
   private String addPrefixToFileName(String fileName, CommitTimelineType commitTimelineType) {


### PR DESCRIPTION
The fix does the following:
1. In case of the continue approach, subsequent pages are picked up from the lastUnprocessedFile
2. Added additional logic to compute lastModifiedAt - it is the maximum value of the last modified at in the files uploaded and also the last file uploaded since for incomplete commit this can be larger. If they come later, they need to filtered out.
3. Added additional logic tom compute lastUploadedFile - if this file is an incomplete commit then keep it as the last uploaded file in the previous checkpoint otherwise take the new file.
4. Added logic to compute start after based on the lastUnprocessedFile in case of continue approach