### PR TITLE
[ENG-26102] Handling getLastUploadedFileFromBatch for rollback commits

### DIFF
--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcher.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcher.java
@@ -233,7 +233,7 @@ public class ActiveTimelineInstantBatcher {
         });
   }
 
-  private static boolean areRelatedInstants(
+  static boolean areRelatedInstants(
       ActiveTimelineInstant instant1,
       ActiveTimelineInstant instant2,
       ActiveTimelineInstant instant3) {
@@ -249,7 +249,7 @@ public class ActiveTimelineInstantBatcher {
   }
 
   // Savepoint and Rollback (Hudi v0.08) instants only have inflight and final commit
-  private static boolean areRelatedSavepointOrRollbackInstants(
+  static boolean areRelatedSavepointOrRollbackInstants(
       ActiveTimelineInstant instant1, ActiveTimelineInstant instant2) {
     if (!instant1.getTimestamp().equals(instant2.getTimestamp())) {
       return false;
@@ -261,7 +261,7 @@ public class ActiveTimelineInstantBatcher {
         VALID_SAVEPOINT_ROLLBACK_ACTIONS.contains(instant1.getAction());
   }
 
-  private static ActiveTimelineInstant getActiveTimeLineInstant(String instant) {
+  static ActiveTimelineInstant getActiveTimeLineInstant(String instant) {
     String[] parts = instant.split("\\.", 3);
 
     String action;
@@ -279,7 +279,7 @@ public class ActiveTimelineInstantBatcher {
 
   @Builder
   @Getter
-  private static class ActiveTimelineInstant {
+  static class ActiveTimelineInstant {
     private final String timestamp;
     private final String action;
     private final String state;

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploaderTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploaderTest.java
@@ -998,6 +998,19 @@ class TimelineCommitInstantsUploaderTest {
             "111.rollback"),
         Arguments.of(
             CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE,
+            Arrays.asList(
+                generateFileObj("000.savepoint", false),
+                generateFileObj("000.savepoint.inflight", false),
+                generateFileObj("111.rollback", false)),
+            "111.rollback"),
+        Arguments.of(
+            CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE,
+            Arrays.asList(
+                generateFileObj("000.rollback", false),
+                generateFileObj("111.rollback", false)),
+            "111.rollback"),
+        Arguments.of(
+            CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE,
             Collections.singletonList(
                 generateFileObj("hoodie.properties", false)),
             "hoodie.properties"),

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploaderTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploaderTest.java
@@ -17,8 +17,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import ai.onehouse.exceptions.AccessDeniedException;
-import ai.onehouse.exceptions.RateLimitException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import ai.onehouse.api.OnehouseApiClient;

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploaderTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploaderTest.java
@@ -1012,8 +1012,8 @@ class TimelineCommitInstantsUploaderTest {
         Arguments.of(
             CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE,
             Collections.singletonList(
-                generateFileObj("hoodie.properties", false)),
-            "hoodie.properties"),
+                generateFileObj("111.rollback", false)),
+            "111.rollback"),
         Arguments.of(
             CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE,
             Arrays.asList(


### PR DESCRIPTION
Handling getLastUploadedFileFromBatch for rollback commits.
There can be 3 cases:
1. Rollback commit with inflight and requested (ideal case with hudi 0.14)
2. Rollback commit with inflight (with Hudi 0.08)
3. Single rollback commit (corner case which can happen ocassionally)

The batches are generated such that the rollback complete commit is always present.