### PR TITLE
[ENG-28276] Updated non error log to debug

### DIFF
--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -98,7 +98,7 @@ public class TableDiscoveryService {
                 String tableId = extractTableId(basePathConfig);
                 if (StringUtils.isNotBlank(tableId)) {
                   if (discoveredTables.size() != 1) {
-                    log.error(
+                    log.debug(
                         String.format(
                             "For tableId %s, there must be exactly one table in path %s",
                             tableId, extractBasePath(basePathConfig)));


### PR DESCRIPTION
Updated non error log to debug:
This log is causing noise while debugging for errors in customers. It is not a condition we need to alert for or has any action items hence making it debug.

Testing:
This is already covered in existing UTs and is a trivial logging change.