### PR TITLE
[ENG-25705] add timeout for build jobs. 

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
 
     steps:
       - name: Fail if image tags is empty

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout repository (with submodules)
         uses: actions/checkout@v4


### PR DESCRIPTION
Add timeout based on usage to control how long the pipeline can run to prevent huge bill. 