### PR TITLE
[ENG-29486] Setting values for retries and max concurrency

### DIFF
--- a/lakeview/src/main/java/ai/onehouse/config/models/configv1/MetadataExtractorConfig.java
+++ b/lakeview/src/main/java/ai/onehouse/config/models/configv1/MetadataExtractorConfig.java
@@ -53,6 +53,12 @@ public class MetadataExtractorConfig {
 
   @Builder.Default private int waitTimeBeforeShutdown = WAIT_TIME_BEFORE_SHUTDOWN;
 
+  @Builder.Default private int objectStoreNumRetries = 10;
+
+  @Builder.Default private int nettyMaxConcurrency = 50;
+
+  @Builder.Default private long nettyConnectionTimeoutSeconds = 60L;
+
   public enum JobRunMode {
     CONTINUOUS,
     ONCE,

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -4,6 +4,7 @@ import static ai.onehouse.constants.MetadataExtractorConstants.HOODIE_FOLDER_NAM
 import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataExtractorFailureReason;
 import static java.util.Collections.emptySet;
 
+import ai.onehouse.RuntimeModule;
 import com.google.inject.Inject;
 import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.config.ConfigProvider;
@@ -43,7 +44,7 @@ public class TableDiscoveryService {
 
   @Inject
   public TableDiscoveryService(
-      @Nonnull AsyncStorageClient asyncStorageClient,
+      @Nonnull @RuntimeModule.TableDiscoveryObjectStorageAsyncClient AsyncStorageClient asyncStorageClient,
       @Nonnull StorageUtils storageUtils,
       @Nonnull ConfigProvider configProvider,
       @Nonnull ExecutorService executorService,

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploader.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploader.java
@@ -13,6 +13,7 @@ import static ai.onehouse.metadata_extractor.ActiveTimelineInstantBatcher.areRel
 import static ai.onehouse.metadata_extractor.ActiveTimelineInstantBatcher.getActiveTimeLineInstant;
 import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataExtractorFailureReason;
 
+import ai.onehouse.RuntimeModule;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -67,7 +68,7 @@ public class TimelineCommitInstantsUploader {
 
   @Inject
   public TimelineCommitInstantsUploader(
-      @Nonnull AsyncStorageClient asyncStorageClient,
+      @Nonnull @RuntimeModule.TableMetadataUploadObjectStorageAsyncClient AsyncStorageClient asyncStorageClient,
       @Nonnull PresignedUrlFileUploader presignedUrlFileUploader,
       @Nonnull OnehouseApiClient onehouseApiClient,
       @Nonnull StorageUtils storageUtils,

--- a/lakeview/src/main/java/ai/onehouse/storage/S3AsyncStorageClient.java
+++ b/lakeview/src/main/java/ai/onehouse/storage/S3AsyncStorageClient.java
@@ -175,6 +175,7 @@ public class S3AsyncStorageClient extends AbstractAsyncStorageClient {
       }
     } else if (wrappedException instanceof SdkClientException) {
       SdkClientException sdkClientException = (SdkClientException) wrappedException;
+      log.info("Error in S3 Acquire operation : {} on path : {} message : {}", operation, path, sdkClientException.getMessage());
       if (sdkClientException.getMessage() != null &&
           sdkClientException.getMessage().contains("Acquire operation took longer than the configured maximum time")) {
         return new RateLimitException(String.format("Throttled by S3 (connection pool exhausted) for operation : %s on path : %s", operation, path));

--- a/lakeview/src/main/java/ai/onehouse/storage/providers/S3AsyncClientProvider.java
+++ b/lakeview/src/main/java/ai/onehouse/storage/providers/S3AsyncClientProvider.java
@@ -83,12 +83,8 @@ public class S3AsyncClientProvider {
         .retryCondition(RetryCondition.defaultRetryCondition())
         .build();
 
-    ClientOverrideConfiguration overrideConfig = ClientOverrideConfiguration.builder()
-        .retryPolicy(retryPolicy)
-        .build();
-
     return s3AsyncClientBuilder
-      .overrideConfiguration(overrideConfig)
+      .overrideConfiguration(builder -> builder.retryPolicy(retryPolicy))
       .httpClient(NettyNioAsyncHttpClient.builder()
         .maxConcurrency(metadataExtractorConfig.getNettyMaxConcurrency())
         .connectionTimeout(Duration.ofSeconds(metadataExtractorConfig.getNettyConnectionTimeoutSeconds()))

--- a/lakeview/src/main/java/ai/onehouse/storage/providers/S3AsyncClientProvider.java
+++ b/lakeview/src/main/java/ai/onehouse/storage/providers/S3AsyncClientProvider.java
@@ -38,7 +38,6 @@ public class S3AsyncClientProvider {
   private static S3AsyncClient s3AsyncClient;
   private static final Logger logger = LoggerFactory.getLogger(S3AsyncClientProvider.class);
 
-  @Inject
   public S3AsyncClientProvider(@Nonnull Config config, @Nonnull ExecutorService executorService) {
     FileSystemConfiguration fileSystemConfiguration = config.getFileSystemConfiguration();
     this.s3Config = fileSystemConfiguration.getS3Config();

--- a/lakeview/src/test/java/ai/onehouse/TestRuntimeModule.java
+++ b/lakeview/src/test/java/ai/onehouse/TestRuntimeModule.java
@@ -19,6 +19,7 @@ import ai.onehouse.storage.providers.GcsClientProvider;
 import ai.onehouse.storage.providers.S3AsyncClientProvider;
 import java.util.concurrent.ExecutorService;
 import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -63,18 +64,39 @@ class TestRuntimeModule {
       when(mockGcsClientProvider.getGcsClient()).thenReturn(null);
     }
 
-    AsyncStorageClient asyncStorageClient =
-        RuntimeModule.providesAsyncStorageClient(
+    AsyncStorageClient asyncStorageClientForDiscovery =
+        RuntimeModule.providesAsyncStorageClientForDiscovery(
             mockConfig,
             mockStorageUtils,
             mockS3AsyncClientProvider,
             mockGcsClientProvider,
             mockExecutorService);
     if (FileSystem.S3.equals(fileSystemType)) {
-      assertTrue(asyncStorageClient instanceof S3AsyncStorageClient);
+      assertTrue(asyncStorageClientForDiscovery instanceof S3AsyncStorageClient);
     } else {
-      assertTrue(asyncStorageClient instanceof GCSAsyncStorageClient);
+      assertTrue(asyncStorageClientForDiscovery instanceof GCSAsyncStorageClient);
     }
+
+    AsyncStorageClient asyncStorageClientForUpload =
+        RuntimeModule.providesAsyncStorageClientForUpload(
+            mockConfig,
+            mockStorageUtils,
+            mockS3AsyncClientProvider,
+            mockGcsClientProvider,
+            mockExecutorService);
+    if (FileSystem.S3.equals(fileSystemType)) {
+      Assertions.assertInstanceOf(S3AsyncStorageClient.class, asyncStorageClientForUpload);
+    } else {
+      Assertions.assertInstanceOf(GCSAsyncStorageClient.class, asyncStorageClientForUpload);
+    }
+
+    S3AsyncClientProvider s3AsyncClientProviderForDiscovery =
+        RuntimeModule.providesS3AsyncClientProviderForDiscovery(mockConfig, mockExecutorService);
+    Assertions.assertInstanceOf(S3AsyncClientProvider.class, s3AsyncClientProviderForDiscovery);
+
+    S3AsyncClientProvider s3AsyncClientProviderForUpload =
+        RuntimeModule.providesS3AsyncClientProviderForUpload(mockConfig, mockExecutorService);
+    Assertions.assertInstanceOf(S3AsyncClientProvider.class, s3AsyncClientProviderForUpload);
   }
 
   @Test

--- a/lakeview/src/test/java/ai/onehouse/storage/providers/S3AsyncClientProviderTest.java
+++ b/lakeview/src/test/java/ai/onehouse/storage/providers/S3AsyncClientProviderTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Stream;
 
+import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,6 +34,7 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 class S3AsyncClientProviderTest {
   @Mock private ConfigV1 config;
   @Mock private FileSystemConfiguration fileSystemConfiguration;
+  @Mock private MetadataExtractorConfig metadataExtractorConfig;
   @Mock private S3Config s3Config;
   @Mock private ExecutorService executorService;
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -72,6 +74,10 @@ class S3AsyncClientProviderTest {
   void testCreateS3AsyncClientWithCredentialsWhenProvided(boolean isAssumedRoleFlow, boolean isRefreshSession) {
     when(config.getFileSystemConfiguration()).thenReturn(fileSystemConfiguration);
     when(fileSystemConfiguration.getS3Config()).thenReturn(s3Config);
+    when(config.getMetadataExtractorConfig()).thenReturn(metadataExtractorConfig);
+    when(metadataExtractorConfig.getObjectStoreNumRetries()).thenReturn(10);
+    when(metadataExtractorConfig.getNettyMaxConcurrency()).thenReturn(50);
+    when(metadataExtractorConfig.getNettyConnectionTimeoutSeconds()).thenReturn(60L);
     if (isAssumedRoleFlow) {
       when(s3Config.getArnToImpersonate()).thenReturn(Optional.of("arn:aws:iam::396675327081:role/test-role"));
     } else {


### PR DESCRIPTION
1. Setting values for retries and max concurrency:
This will help lower the occurrences of client rate limit from AWS side.
Will also adjust the alert thresholds for this.

2. Split the clients for upload and discovery services
