### PR TITLE
[ENG-31011]: Added logging for extractor failures

### DIFF
--- a/lakeview/src/main/java/ai/onehouse/api/OnehouseApiClient.java
+++ b/lakeview/src/main/java/ai/onehouse/api/OnehouseApiClient.java
@@ -177,10 +177,12 @@ public class OnehouseApiClient {
   private void emmitApiErrorMetric(int apiStatusCode) {
     if (ACCEPTABLE_HTTP_FAILURE_STATUS_CODES.contains(apiStatusCode)) {
       hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
-          MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR);
+          MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR,
+          String.format("API call failed with status code: %d (user error)", apiStatusCode));
     } else {
       hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
-          MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR);
+          MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR,
+          String.format("API call failed with status code: %d (system error)", apiStatusCode));
     }
   }
 }

--- a/lakeview/src/main/java/ai/onehouse/api/OnehouseApiClient.java
+++ b/lakeview/src/main/java/ai/onehouse/api/OnehouseApiClient.java
@@ -163,7 +163,7 @@ public class OnehouseApiClient {
           }
         }
         response.close();
-        emmitApiErrorMetric(response.code());
+        emmitApiErrorMetric(response.code(), errorResponse);
         return errorResponse;
       } catch (InstantiationException
           | IllegalAccessException
@@ -174,15 +174,21 @@ public class OnehouseApiClient {
     }
   }
 
-  private void emmitApiErrorMetric(int apiStatusCode) {
+  private void emmitApiErrorMetric(int apiStatusCode, Object errorResponse) {
+    String errorCause = "";
+    if (errorResponse instanceof ApiResponse) {
+      ApiResponse apiResponse = (ApiResponse) errorResponse;
+      errorCause = apiResponse.getCause() != null ? apiResponse.getCause() : "Unknown error";
+    }
+    
     if (ACCEPTABLE_HTTP_FAILURE_STATUS_CODES.contains(apiStatusCode)) {
       hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
           MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR,
-          String.format("API call failed with status code: %d (user error)", apiStatusCode));
+          String.format("API call failed with status code: %d - %s", apiStatusCode, errorCause));
     } else {
       hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
           MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR,
-          String.format("API call failed with status code: %d (system error)", apiStatusCode));
+          String.format("API call failed with status code: %d - %s", apiStatusCode, errorCause));
     }
   }
 }

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/HoodiePropertiesReader.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/HoodiePropertiesReader.java
@@ -53,7 +53,8 @@ public class HoodiePropertiesReader {
               hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
                 getMetadataExtractorFailureReason(
                     throwable,
-                    MetricsConstants.MetadataUploadFailureReasons.HOODIE_PROPERTY_NOT_FOUND_OR_CORRUPTED)
+                    MetricsConstants.MetadataUploadFailureReasons.HOODIE_PROPERTY_NOT_FOUND_OR_CORRUPTED),
+                String.format("Error reading hoodie properties file: %s", throwable.getMessage())
               );
               return null;
             });

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableMetadataUploaderService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableMetadataUploaderService.java
@@ -178,7 +178,8 @@ public class TableMetadataUploaderService {
               hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
                   getMetadataExtractorFailureReason(
                       throwable,
-                      MetricsConstants.MetadataUploadFailureReasons.UNKNOWN));
+                      MetricsConstants.MetadataUploadFailureReasons.UNKNOWN),
+                  String.format("Exception when uploading instants: %s", throwable.getMessage()));
               return false;
             });
   }
@@ -238,7 +239,8 @@ public class TableMetadataUploaderService {
                     if (initializeSingleTableMetricsCheckpointRequestList.isEmpty()) {
                       log.error("No valid table to initialise");
                       hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
-                          MetricsConstants.MetadataUploadFailureReasons.NO_TABLES_TO_INITIALIZE);
+                          MetricsConstants.MetadataUploadFailureReasons.NO_TABLES_TO_INITIALIZE,
+                          "No valid table to initialise");
                       return CompletableFuture.completedFuture(null);
                     }
 
@@ -296,7 +298,8 @@ public class TableMetadataUploaderService {
                       }
                       if (!StringUtils.isBlank(response.getError())) {
                         hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
-                            MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR);
+                            MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR,
+                            String.format("Error initialising table %s: %s", table, response.getError()));
                         log.error(
                             "Error initialising table: {} error: {}, skipping table processing",
                             table,

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploader.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploader.java
@@ -182,7 +182,8 @@ public class TimelineCommitInstantsUploader {
               hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
                   getMetadataExtractorFailureReason(
                       throwable,
-                      MetricsConstants.MetadataUploadFailureReasons.UNKNOWN));
+                      MetricsConstants.MetadataUploadFailureReasons.UNKNOWN),
+                  String.format("Exception when uploading instants for table %s timeline %s: %s", table, commitTimelineType, throwable.getMessage()));
               return null; // handled in uploadNewInstantsSinceCheckpoint function
             });
   }
@@ -250,7 +251,8 @@ public class TimelineCommitInstantsUploader {
               hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
                   getMetadataExtractorFailureReason(
                       throwable,
-                      MetricsConstants.MetadataUploadFailureReasons.UNKNOWN));
+                      MetricsConstants.MetadataUploadFailureReasons.UNKNOWN),
+                  String.format("Exception when uploading instants for table %s timeline %s: %s", table, commitTimelineType, throwable.getMessage()));
               return null; // handled in uploadNewInstantsSinceCheckpoint
             });
   }
@@ -373,7 +375,8 @@ public class TimelineCommitInstantsUploader {
                               .incrementTableMetadataProcessingFailureCounter(
                                   getMetadataExtractorFailureReason(
                                       throwable,
-                                      MetricsConstants.MetadataUploadFailureReasons.UNKNOWN));
+                                      MetricsConstants.MetadataUploadFailureReasons.UNKNOWN),
+                                  String.format("Error processing batch for table %s: %s", table.getAbsoluteTableUri(), throwable.getMessage()));
                           log.error(
                               "error processing batch for table: {}. Skipping processing of further batches of table in current run.",
                               table.getAbsoluteTableUri(),

--- a/lakeview/src/main/java/ai/onehouse/metrics/LakeViewExtractorMetrics.java
+++ b/lakeview/src/main/java/ai/onehouse/metrics/LakeViewExtractorMetrics.java
@@ -9,8 +9,12 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import lombok.Getter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LakeViewExtractorMetrics {
+  private static final Logger log = LoggerFactory.getLogger(LakeViewExtractorMetrics.class);
+  
   private final Metrics metrics;
   private final Metrics.Gauge tablesDiscoveredGaugeMetric;
   private final Metrics.Gauge tablesProcessedGaugeMetric;
@@ -92,10 +96,11 @@ public class LakeViewExtractorMetrics {
   }
 
   public void incrementTableMetadataProcessingFailureCounter(
-      MetricsConstants.MetadataUploadFailureReasons metadataUploadFailureReasons) {
+      MetricsConstants.MetadataUploadFailureReasons metadataUploadFailureReasons, String failureReason) {
     List<Tag> tags = getDefaultTags();
     tags.add(Tag.of(METADATA_UPLOAD_FAILURE_REASON_TAG_KEY, metadataUploadFailureReasons.name()));
     metrics.increment(TABLE_METADATA_PROCESSING_FAILURE_COUNTER, tags);
+    log.error("Table metadata processing failed with reason: {} - {}", metadataUploadFailureReasons.name(), failureReason);
   }
 
   public void resetTableProcessedGauge() {

--- a/lakeview/src/main/java/ai/onehouse/storage/PresignedUrlFileUploader.java
+++ b/lakeview/src/main/java/ai/onehouse/storage/PresignedUrlFileUploader.java
@@ -58,7 +58,8 @@ public class PresignedUrlFileUploader {
                                     hudiMetadataExtractorMetrics
                                         .incrementTableMetadataProcessingFailureCounter(
                                             MetricsConstants.MetadataUploadFailureReasons
-                                                .PRESIGNED_URL_UPLOAD_FAILURE);
+                                                .PRESIGNED_URL_UPLOAD_FAILURE,
+                                            String.format("File upload failed: response code: %s error message: %s", statusCode, message));
                                     throw new FileUploadException(
                                         String.format(
                                             "File upload failed: response code: %s error message: %s",

--- a/lakeview/src/test/java/ai/onehouse/api/OnehouseApiClientTest.java
+++ b/lakeview/src/test/java/ai/onehouse/api/OnehouseApiClientTest.java
@@ -15,6 +15,7 @@ import static ai.onehouse.constants.ApiConstants.UPSERT_TABLE_METRICS_CHECKPOINT
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -154,9 +155,8 @@ class OnehouseApiClientTest {
     assertTrue(result.isFailure());
     verify(hudiMetadataExtractorMetrics)
         .incrementTableMetadataProcessingFailureCounter(
-            failureStatusCode == FAILURE_STATUS_CODE_SYSTEM
-                ? MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR
-                : MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR);
+            any(MetricsConstants.MetadataUploadFailureReasons.class),
+            anyString());
     assertEquals(failureStatusCode, result.getStatusCode());
     if (failureStatusCode == FAILURE_STATUS_CODE_UNAUTHORIZED) {
       assertEquals(UNAUTHORIZED_ERROR_MESSAGE, result.getCause());
@@ -191,9 +191,8 @@ class OnehouseApiClientTest {
     assertTrue(result.isFailure());
     verify(hudiMetadataExtractorMetrics)
         .incrementTableMetadataProcessingFailureCounter(
-            failureStatusCode == FAILURE_STATUS_CODE_SYSTEM
-                ? MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR
-                : MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR);
+            any(MetricsConstants.MetadataUploadFailureReasons.class),
+            anyString());
     assertEquals(failureStatusCode, result.getStatusCode());
     if (failureStatusCode == FAILURE_STATUS_CODE_UNAUTHORIZED) {
       assertEquals(UNAUTHORIZED_ERROR_MESSAGE, result.getCause());

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/HoodiePropertiesReaderTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/HoodiePropertiesReaderTest.java
@@ -1,6 +1,8 @@
 package ai.onehouse.metadata_extractor;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -79,7 +81,8 @@ class HoodiePropertiesReaderTest {
     assertNull(futureResult.join());
     verify(hudiMetadataExtractorMetrics)
         .incrementTableMetadataProcessingFailureCounter(
-            MetricsConstants.MetadataUploadFailureReasons.HOODIE_PROPERTY_NOT_FOUND_OR_CORRUPTED);
+            any(MetricsConstants.MetadataUploadFailureReasons.class),
+            anyString());
   }
 
   @Test
@@ -94,7 +97,8 @@ class HoodiePropertiesReaderTest {
     assertNull(futureResult.join());
     verify(hudiMetadataExtractorMetrics)
             .incrementTableMetadataProcessingFailureCounter(
-                    MetricsConstants.MetadataUploadFailureReasons.RATE_LIMITING);
+                    any(MetricsConstants.MetadataUploadFailureReasons.class),
+                    anyString());
   }
 
   public static <R> CompletableFuture<R> failedFuture(Throwable error) {

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableMetadataUploaderServiceTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableMetadataUploaderServiceTest.java
@@ -3,6 +3,7 @@ package ai.onehouse.metadata_extractor;
 import static ai.onehouse.constants.MetadataExtractorConstants.*;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -164,7 +165,8 @@ class TableMetadataUploaderServiceTest {
             eq(CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE));
     verify(hudiMetadataExtractorMetrics)
         .incrementTableMetadataProcessingFailureCounter(
-            MetricsConstants.MetadataUploadFailureReasons.NO_TABLES_TO_INITIALIZE);
+            any(MetricsConstants.MetadataUploadFailureReasons.class),
+            anyString());
   }
 
   private void setupInitialiseTableMetricsCheckpointSuccessMocks(

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableMetadataUploaderServiceTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableMetadataUploaderServiceTest.java
@@ -493,6 +493,72 @@ class TableMetadataUploaderServiceTest {
     // with just once
   }
 
+  @Test
+  void testUploadInstantsInTableBatchExceptionallyBlock() {
+    // Create a CompletableFuture that will complete exceptionally
+    CompletableFuture<GetTableMetricsCheckpointResponse> failedFuture = new CompletableFuture<>();
+    RuntimeException testException = new RuntimeException("Test exception for exceptionally block");
+    failedFuture.completeExceptionally(testException);
+
+    when(onehouseApiClient.getTableMetricsCheckpoints(
+            Collections.singletonList(TABLE_ID.toString())))
+        .thenReturn(failedFuture);
+
+    // Execute the method and verify it returns false
+    Boolean result = tableMetadataUploaderService.uploadInstantsInTables(Collections.singleton(TABLE)).join();
+    assertFalse(result);
+
+    // Verify that the metrics were called with the correct parameters
+    verify(hudiMetadataExtractorMetrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            any(MetricsConstants.MetadataUploadFailureReasons.class),
+            anyString());
+  }
+
+  @Test
+  void testUploadInstantsInTableBatchExceptionallyBlockWithSpecificException() {
+    // Test with a specific exception type to verify the failure reason mapping
+    CompletableFuture<GetTableMetricsCheckpointResponse> failedFuture = new CompletableFuture<>();
+    RuntimeException testException = new RuntimeException("Network timeout during checkpoint fetch");
+    failedFuture.completeExceptionally(testException);
+
+    when(onehouseApiClient.getTableMetricsCheckpoints(
+            Collections.singletonList(TABLE_ID.toString())))
+        .thenReturn(failedFuture);
+
+    // Execute the method and verify it returns false
+    Boolean result = tableMetadataUploaderService.uploadInstantsInTables(Collections.singleton(TABLE)).join();
+    assertFalse(result);
+
+    // Verify that the metrics were called with UNKNOWN reason (since RuntimeException doesn't map to specific reasons)
+    verify(hudiMetadataExtractorMetrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.UNKNOWN),
+            eq("Exception when uploading instants: java.lang.RuntimeException: Network timeout during checkpoint fetch"));
+  }
+
+  @Test
+  void testUploadInstantsInTableBatchExceptionallyBlockWithNullMessage() {
+    // Test with an exception that has a null message
+    CompletableFuture<GetTableMetricsCheckpointResponse> failedFuture = new CompletableFuture<>();
+    RuntimeException testException = new RuntimeException((String) null);
+    failedFuture.completeExceptionally(testException);
+
+    when(onehouseApiClient.getTableMetricsCheckpoints(
+            Collections.singletonList(TABLE_ID.toString())))
+        .thenReturn(failedFuture);
+
+    // Execute the method and verify it returns false
+    Boolean result = tableMetadataUploaderService.uploadInstantsInTables(Collections.singleton(TABLE)).join();
+    assertFalse(result);
+
+    // Verify that the metrics were called with UNKNOWN reason and null message handling
+    verify(hudiMetadataExtractorMetrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.UNKNOWN),
+            eq("Exception when uploading instants: java.lang.RuntimeException"));
+  }
+
   private Checkpoint generateCheckpointObj(
       int batchId,
       Instant checkpointTimestamp,

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploaderTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TimelineCommitInstantsUploaderTest.java
@@ -867,7 +867,8 @@ class TimelineCommitInstantsUploaderTest {
     verifyNoMoreInteractions(presignedUrlFileUploader);
     verify(hudiMetadataExtractorMetrics)
         .incrementTableMetadataProcessingFailureCounter(
-            MetricsConstants.MetadataUploadFailureReasons.UNKNOWN);
+            any(MetricsConstants.MetadataUploadFailureReasons.class),
+            anyString());
   }
 
   @Test
@@ -941,7 +942,8 @@ class TimelineCommitInstantsUploaderTest {
     verify(onehouseApiClient, times(1)).upsertTableMetricsCheckpoint(any());
     verify(hudiMetadataExtractorMetrics)
         .incrementTableMetadataProcessingFailureCounter(
-            MetricsConstants.MetadataUploadFailureReasons.UNKNOWN);
+            any(MetricsConstants.MetadataUploadFailureReasons.class),
+            anyString());
   }
 
   @Test

--- a/lakeview/src/test/java/ai/onehouse/metrics/LakeViewExtractorMetricsTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metrics/LakeViewExtractorMetricsTest.java
@@ -91,7 +91,8 @@ class LakeViewExtractorMetricsTest {
   void testIncrementTableMetadataUploadFailureCounter() {
     MetricsConstants.MetadataUploadFailureReasons reason =
         MetricsConstants.MetadataUploadFailureReasons.UNKNOWN;
-    hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(reason);
+    String failureReason = "Test failure reason";
+    hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(reason, failureReason);
     List<Tag> tags = getDefaultTags();
     tags.add(Tag.of(METADATA_UPLOAD_FAILURE_REASON_TAG_KEY, reason.name()));
     verify(metrics).increment(TABLE_METADATA_PROCESSING_FAILURE_COUNTER, tags);

--- a/lakeview/src/test/java/ai/onehouse/storage/PresignedUrlFileUploaderTest.java
+++ b/lakeview/src/test/java/ai/onehouse/storage/PresignedUrlFileUploaderTest.java
@@ -135,7 +135,8 @@ class PresignedUrlFileUploaderTest {
         exception.getMessage());
     verify(hudiMetadataExtractorMetrics)
         .incrementTableMetadataProcessingFailureCounter(
-            MetricsConstants.MetadataUploadFailureReasons.PRESIGNED_URL_UPLOAD_FAILURE);
+            any(MetricsConstants.MetadataUploadFailureReasons.class),
+            anyString());
     verifyRequestPayloadForSmallerFiles();
   }
 


### PR DESCRIPTION
Added logging whenever we emit the metric. This will make it easy to debug.