### PR TITLE
[ENG-40573] Fix AzureAsyncStorageClient.readBlob truncating files to last chunk

### DIFF
--- a/lakeview/src/main/java/ai/onehouse/storage/AzureAsyncStorageClient.java
+++ b/lakeview/src/main/java/ai/onehouse/storage/AzureAsyncStorageClient.java
@@ -119,7 +119,10 @@ public class AzureAsyncStorageClient extends AbstractAsyncStorageClient {
         () -> {
           try {
             DataLakeFileAsyncClient fileClient = getFileClient(azureUri);
-            return BinaryData.fromBytes(fileClient.read().blockLast().array());
+            // fileClient.read() returns a Flux<ByteBuffer> of chunks; use fromFlux so
+            // the full content is aggregated. Using blockLast().array() kept only the
+            // last chunk, silently truncating any file larger than one download chunk.
+            return BinaryData.fromFlux(fileClient.read()).block();
           } catch (Exception ex) {
             log.error("Failed to read file", ex);
             throw clientException(ex, "readBlob", azureUri);

--- a/lakeview/src/main/java/ai/onehouse/storage/AzureAsyncStorageClient.java
+++ b/lakeview/src/main/java/ai/onehouse/storage/AzureAsyncStorageClient.java
@@ -119,9 +119,6 @@ public class AzureAsyncStorageClient extends AbstractAsyncStorageClient {
         () -> {
           try {
             DataLakeFileAsyncClient fileClient = getFileClient(azureUri);
-            // fileClient.read() returns a Flux<ByteBuffer> of chunks; use fromFlux so
-            // the full content is aggregated. Using blockLast().array() kept only the
-            // last chunk, silently truncating any file larger than one download chunk.
             return BinaryData.fromFlux(fileClient.read()).block();
           } catch (Exception ex) {
             log.error("Failed to read file", ex);

--- a/lakeview/src/test/java/ai/onehouse/storage/AzureAsyncStorageClientTest.java
+++ b/lakeview/src/test/java/ai/onehouse/storage/AzureAsyncStorageClientTest.java
@@ -194,8 +194,6 @@ class AzureAsyncStorageClientTest {
   @Test
   void testReadBlobMultipleChunks() throws ExecutionException, InterruptedException {
     // Azure SDK streams larger files as multiple ByteBuffer chunks. Previously the
-    // code used blockLast().array() which silently dropped every chunk except the
-    // last one, truncating files larger than one download chunk.
     byte[] chunk1 = "first chunk ".getBytes(StandardCharsets.UTF_8);
     byte[] chunk2 = "second chunk ".getBytes(StandardCharsets.UTF_8);
     byte[] chunk3 = "third chunk".getBytes(StandardCharsets.UTF_8);

--- a/lakeview/src/test/java/ai/onehouse/storage/AzureAsyncStorageClientTest.java
+++ b/lakeview/src/test/java/ai/onehouse/storage/AzureAsyncStorageClientTest.java
@@ -193,23 +193,27 @@ class AzureAsyncStorageClientTest {
 
   @Test
   void testReadBlobMultipleChunks() throws ExecutionException, InterruptedException {
-    // Azure SDK streams larger files as multiple ByteBuffer chunks. Previously the
-    byte[] chunk1 = "first chunk ".getBytes(StandardCharsets.UTF_8);
-    byte[] chunk2 = "second chunk ".getBytes(StandardCharsets.UTF_8);
-    byte[] chunk3 = "third chunk".getBytes(StandardCharsets.UTF_8);
-    byte[] expected = "first chunk second chunk third chunk".getBytes(StandardCharsets.UTF_8);
+    byte[] chunk1 = new byte[8192];
+    Arrays.fill(chunk1, (byte) 'A');
+    byte[] chunk2 = "mp_completion_time".getBytes(StandardCharsets.UTF_8);
+
+    byte[] expected = new byte[chunk1.length + chunk2.length];
+    System.arraycopy(chunk1, 0, expected, 0, chunk1.length);
+    System.arraycopy(chunk2, 0, expected, chunk1.length, chunk2.length);
 
     when(mockDataLakeServiceAsyncClient.getFileSystemAsyncClient(TEST_CONTAINER))
         .thenReturn(mockFileSystemAsyncClient);
     when(mockFileSystemAsyncClient.getFileAsyncClient(TEST_FILE)).thenReturn(mockFileAsyncClient);
     when(mockFileAsyncClient.read())
-        .thenReturn(
-            Flux.just(ByteBuffer.wrap(chunk1), ByteBuffer.wrap(chunk2), ByteBuffer.wrap(chunk3)));
+        .thenReturn(Flux.just(ByteBuffer.wrap(chunk1), ByteBuffer.wrap(chunk2)));
 
     BinaryData result = azureAsyncStorageClient.readBlob(AZURE_URI).get();
 
     assertNotNull(result);
     assertArrayEquals(expected, result.toBytes());
+    assertEquals(8192 + 18, result.toBytes().length);
+    assertTrue(new String(result.toBytes(), StandardCharsets.UTF_8).startsWith("AAAA"));
+    assertTrue(new String(result.toBytes(), StandardCharsets.UTF_8).endsWith("mp_completion_time"));
   }
 
   @Test

--- a/lakeview/src/test/java/ai/onehouse/storage/AzureAsyncStorageClientTest.java
+++ b/lakeview/src/test/java/ai/onehouse/storage/AzureAsyncStorageClientTest.java
@@ -192,6 +192,29 @@ class AzureAsyncStorageClientTest {
   }
 
   @Test
+  void testReadBlobMultipleChunks() throws ExecutionException, InterruptedException {
+    // Azure SDK streams larger files as multiple ByteBuffer chunks. Previously the
+    // code used blockLast().array() which silently dropped every chunk except the
+    // last one, truncating files larger than one download chunk.
+    byte[] chunk1 = "first chunk ".getBytes(StandardCharsets.UTF_8);
+    byte[] chunk2 = "second chunk ".getBytes(StandardCharsets.UTF_8);
+    byte[] chunk3 = "third chunk".getBytes(StandardCharsets.UTF_8);
+    byte[] expected = "first chunk second chunk third chunk".getBytes(StandardCharsets.UTF_8);
+
+    when(mockDataLakeServiceAsyncClient.getFileSystemAsyncClient(TEST_CONTAINER))
+        .thenReturn(mockFileSystemAsyncClient);
+    when(mockFileSystemAsyncClient.getFileAsyncClient(TEST_FILE)).thenReturn(mockFileAsyncClient);
+    when(mockFileAsyncClient.read())
+        .thenReturn(
+            Flux.just(ByteBuffer.wrap(chunk1), ByteBuffer.wrap(chunk2), ByteBuffer.wrap(chunk3)));
+
+    BinaryData result = azureAsyncStorageClient.readBlob(AZURE_URI).get();
+
+    assertNotNull(result);
+    assertArrayEquals(expected, result.toBytes());
+  }
+
+  @Test
   void testStreamFileAsync() throws ExecutionException, InterruptedException, IOException {
     byte[] fileContent = "test content".getBytes(StandardCharsets.UTF_8);
     ByteBuffer byteBuffer = ByteBuffer.wrap(fileContent);


### PR DESCRIPTION
## Summary

- `fileClient.read()` returns `Flux<ByteBuffer>` — one buffer per HTTP chunk delivered by the Azure SDK Netty client (~8 KB each). The previous `blockLast().array()` silently discarded every chunk except the final one, leaving any file larger than a single download chunk uploaded to the lakeview mirror bucket truncated to just its tail.
- Replace with `BinaryData.fromFlux(fileClient.read()).block()` so the entire response stream is aggregated.
- Add a multi-chunk unit test that exercises the Flux-aggregation path.

## Incident context (ENG-40451)

PagerDuty [#65265](https://onehouse.pagerduty.com/incidents/Q08C7MRRW18E9U) — `CEMetricsIngestionJobProcessingFailure`, Sev1, for org `06bf5da5-ce19-42ba-857e-d0e0b4442718`, table `airflow_spark_jobs_db/af_scheduled_table_1`.

CP `community-edition` saw:

```
HoodieIOException: Unable to read metadata for instant [20260331220335439__deltacommit__COMPLETED__...]
Caused by: JsonParseException: Unrecognized token 'mp' at line 1, column 1
```

Root cause trace:

| source | file | size | first bytes |
|---|---|---|---|
| Customer Azure `.hoodie/20260331220335439.deltacommit` | 8 279 bytes | `7b 0a 20 20 22 70` → `{\n  "p` | valid JSON |
| Mirror `gs://onehouse-lakeview-production/.../20260331220335439.deltacommit` | **87 bytes** | `6d 70 5c 22 2c 5c` → `mp\",\"` | exact tail of original |

`8279 − 87 = 8192` — one Azure HTTP download chunk. The mirror got only the final `blockLast()` chunk; `mp` is where the middle of the JSON string `"writeSchema": "{...model_line..."` happened to split.

## Test plan

- [x] `./gradlew :lakeview:test --tests ai.onehouse.storage.AzureAsyncStorageClientTest` — all 14 pass, new `testReadBlobMultipleChunks` in particular.
- [ ] Cherry-pick to `release-v0.27.x` and redeploy the customer-side extractor.
- [ ] Re-upload affected `.hoodie/*.deltacommit` files (> one chunk in size) in `gs://onehouse-lakeview-production/` for previously-corrupted tables — at minimum `06bf5da5-…/420f16de-…/airflow_spark_jobs_db/af_scheduled_table_1/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)