### PR TITLE
[ENG-41301] Fix V9 batcher dropping all batches when savepoint shares instant time with deltacommit

### DIFF
--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcher.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcher.java
@@ -17,7 +17,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -58,6 +60,16 @@ public class ActiveTimelineInstantBatcher {
     } else {
       sortedInstants = sortAndFilterInstants(instants);
     }
+
+    // V9/V2 layout: a savepoint pinned to an instant time T produces files
+    // <T>.savepoint.inflight + <T>_<completionTs>.savepoint that lex-sort to
+    // positions 3 and 5 of the same-T deltacommit's 5-file group, breaking the
+    // (inflight, requested, completed) triplet check. Peel complete savepoint
+    // pairs into their own 2-file batches before triplet matching so the
+    // deltacommit/commit at the same T can group cleanly.
+    Pair<List<File>, List<List<File>>> partitioned = extractSavepointPairs(sortedInstants);
+    sortedInstants = partitioned.getLeft();
+    List<List<File>> savepointBatches = partitioned.getRight();
 
     List<List<File>> batches = new ArrayList<>();
     List<File> currentBatch = new ArrayList<>();
@@ -180,7 +192,52 @@ public class ActiveTimelineInstantBatcher {
       batches.add(currentBatch);
     }
 
+    // Append complete savepoint pairs after commit batches. Savepoints carry no
+    // write metadata so order vs commits is benign; placing them last keeps
+    // commit ordering deterministic.
+    batches.addAll(savepointBatches);
+
     return Pair.of(firstIncompleteCheckpoint, batches);
+  }
+
+  /**
+   * Splits {@code sortedInstants} into (a) non-savepoint files retained in their original sort
+   * order and (b) zero or more 2-file batches each containing one fully-paired savepoint
+   * ({@code <ts>.savepoint.inflight} + {@code <ts>_<completionTs>.savepoint}). Partial savepoint
+   * files (only inflight or only completed) stay in the non-savepoint list so the existing
+   * single-savepoint code path can still process them.
+   */
+  private Pair<List<File>, List<List<File>>> extractSavepointPairs(List<File> sortedInstants) {
+    Map<String, List<File>> savepointFilesByTimestamp = new LinkedHashMap<>();
+    List<File> nonSavepoint = new ArrayList<>();
+    for (File f : sortedInstants) {
+      ActiveTimelineInstant inst = getActiveTimeLineInstant(f.getFilename());
+      if (SAVEPOINT_ACTION.equals(inst.getAction())) {
+        savepointFilesByTimestamp
+            .computeIfAbsent(inst.getTimestamp(), k -> new ArrayList<>())
+            .add(f);
+      } else {
+        nonSavepoint.add(f);
+      }
+    }
+    List<List<File>> savepointBatches = new ArrayList<>();
+    for (List<File> spFiles : savepointFilesByTimestamp.values()) {
+      boolean hasInflight =
+          spFiles.stream()
+              .anyMatch(
+                  f -> "inflight".equals(getActiveTimeLineInstant(f.getFilename()).getState()));
+      boolean hasCompleted =
+          spFiles.stream()
+              .anyMatch(
+                  f -> "completed".equals(getActiveTimeLineInstant(f.getFilename()).getState()));
+      if (spFiles.size() == 2 && hasInflight && hasCompleted) {
+        savepointBatches.add(spFiles);
+      } else {
+        nonSavepoint.addAll(spFiles);
+      }
+    }
+    nonSavepoint.sort(getFileComparator());
+    return Pair.of(nonSavepoint, savepointBatches);
   }
 
   private static String getFirstIncompleteCheckpoint(String numericString) {

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcher.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcher.java
@@ -203,12 +203,18 @@ public class ActiveTimelineInstantBatcher {
   /**
    * Splits {@code sortedInstants} into (a) non-savepoint files retained in their original sort
    * order and (b) zero or more 2-file batches each containing one fully-paired savepoint
-   * ({@code <ts>.savepoint.inflight} + {@code <ts>_<completionTs>.savepoint}). Partial savepoint
-   * files (only inflight or only completed) stay in the non-savepoint list so the existing
-   * single-savepoint code path can still process them.
+   * ({@code <ts>.savepoint.inflight} + {@code <ts>_<completionTs>.savepoint}).
+   *
+   * <p>Only a complete savepoint pair that <em>collides</em> with a same-instant non-savepoint
+   * commit is peeled out — that collision is the V9 case where the savepoint's files interleave
+   * with the deltacommit/commit triplet and break the (inflight, requested, completed) check. A
+   * savepoint at its own unique instant time, or a partial savepoint (only inflight or only
+   * completed), is left in the non-savepoint list so the existing inline savepoint code path keeps
+   * processing it in instant-time order.
    */
   private Pair<List<File>, List<List<File>>> extractSavepointPairs(List<File> sortedInstants) {
     Map<String, List<File>> savepointFilesByTimestamp = new LinkedHashMap<>();
+    Set<String> nonSavepointTimestamps = new HashSet<>();
     List<File> nonSavepoint = new ArrayList<>();
     for (File f : sortedInstants) {
       ActiveTimelineInstant inst = getActiveTimeLineInstant(f.getFilename());
@@ -217,11 +223,13 @@ public class ActiveTimelineInstantBatcher {
             .computeIfAbsent(inst.getTimestamp(), k -> new ArrayList<>())
             .add(f);
       } else {
+        nonSavepointTimestamps.add(inst.getTimestamp());
         nonSavepoint.add(f);
       }
     }
     List<List<File>> savepointBatches = new ArrayList<>();
-    for (List<File> spFiles : savepointFilesByTimestamp.values()) {
+    for (Map.Entry<String, List<File>> entry : savepointFilesByTimestamp.entrySet()) {
+      List<File> spFiles = entry.getValue();
       boolean hasInflight =
           spFiles.stream()
               .anyMatch(
@@ -230,7 +238,10 @@ public class ActiveTimelineInstantBatcher {
           spFiles.stream()
               .anyMatch(
                   f -> "completed".equals(getActiveTimeLineInstant(f.getFilename()).getState()));
-      if (spFiles.size() == 2 && hasInflight && hasCompleted) {
+      if (spFiles.size() == 2
+          && hasInflight
+          && hasCompleted
+          && nonSavepointTimestamps.contains(entry.getKey())) {
         savepointBatches.add(spFiles);
       } else {
         nonSavepoint.addAll(spFiles);

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcherTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/ActiveTimelineInstantBatcherTest.java
@@ -607,6 +607,58 @@ class ActiveTimelineInstantBatcherTest {
   }
 
   @Test
+  void testCreateBatchWithV9SavepointSharingInstantTimeWithDeltacommit() {
+    // V9/V2 daily-savepoint workload (e.g. Concentric permissions_bronze): a savepoint is pinned
+    // to the same instant time T as a deltacommit. The savepoint writes <T>.savepoint.inflight +
+    // <T>_<completionTs>.savepoint, which lex-sort into the middle of the deltacommit's triplet and
+    // previously broke the (inflight, requested, completed) check — yielding ZERO batches and
+    // silently halting upload. The fix peels the colliding savepoint pair into its own batch so the
+    // deltacommit triplet groups cleanly; the savepoint pair is appended afterwards.
+    String t1 = "20260430010000000";
+    String t1Complete = "20260430010005000";
+    String t1SavepointComplete = "20260430010010000";
+    String t2 = "20260501010000000";
+    String t2Complete = "20260501010005000";
+    String t2SavepointComplete = "20260501010010000";
+
+    List<File> files =
+        Arrays.asList(
+            generateFileObj("hoodie.properties"),
+            generateFileObj(t1 + ".deltacommit.requested"),
+            generateFileObj(t1 + ".deltacommit.inflight"),
+            generateFileObj(t1 + "_" + t1Complete + ".deltacommit"),
+            generateFileObj(t1 + ".savepoint.inflight"),
+            generateFileObj(t1 + "_" + t1SavepointComplete + ".savepoint"),
+            generateFileObj(t2 + ".deltacommit.requested"),
+            generateFileObj(t2 + ".deltacommit.inflight"),
+            generateFileObj(t2 + "_" + t2Complete + ".deltacommit"),
+            generateFileObj(t2 + ".savepoint.inflight"),
+            generateFileObj(t2 + "_" + t2SavepointComplete + ".savepoint"));
+
+    List<List<File>> expectedBatches =
+        Arrays.asList(
+            Arrays.asList(
+                generateFileObj("hoodie.properties"),
+                generateFileObj(t1 + ".deltacommit.inflight"),
+                generateFileObj(t1 + ".deltacommit.requested"),
+                generateFileObj(t1 + "_" + t1Complete + ".deltacommit")),
+            Arrays.asList(
+                generateFileObj(t2 + ".deltacommit.inflight"),
+                generateFileObj(t2 + ".deltacommit.requested"),
+                generateFileObj(t2 + "_" + t2Complete + ".deltacommit")),
+            Arrays.asList(
+                generateFileObj(t1 + ".savepoint.inflight"),
+                generateFileObj(t1 + "_" + t1SavepointComplete + ".savepoint")),
+            Arrays.asList(
+                generateFileObj(t2 + ".savepoint.inflight"),
+                generateFileObj(t2 + "_" + t2SavepointComplete + ".savepoint")));
+
+    List<List<File>> actualBatches =
+        activeTimelineInstantBatcher.createBatches(files, 4, getCheckpoint()).getRight();
+    assertEquals(expectedBatches, actualBatches);
+  }
+
+  @Test
   void testWithInvalidBatchSize() {
     assertThrows(
         IllegalArgumentException.class,


### PR DESCRIPTION
## Summary
- For V9/V2 tables with daily-savepoint workloads (e.g. Concentric perf), `ActiveTimelineInstantBatcher.createBatches` was returning **zero** batches and silently halting upload of the active timeline.
- The fix peels a savepoint's two files into their own batch — but **only when the savepoint shares an instant time with a non-savepoint commit** (the case that breaks triplet matching). Savepoints at their own unique instant time keep the existing inline, instant-time-ordered path, so prior behavior is preserved.

## Root cause
A savepoint pinned to instant time `T` writes `<T>.savepoint.inflight` + `<T>_<completionTs>.savepoint`. When a deltacommit also exists at the same `T`, after lex-sort the files interleave:

```
1. <T>.deltacommit.inflight
2. <T>.deltacommit.requested
3. <T>.savepoint.inflight      <- intruder
4. <T>_<ct>.deltacommit
5. <T>_<ct>.savepoint
```

Two things break:
1. **The deltacommit triplet is corrupted** — the loop checks files 1–3 expecting `{inflight, requested, completed}` but gets `{inflight, requested, inflight}`. With the default upload strategy this trips `shouldStopIteration=true` at the very first group, producing zero batches.
2. **The savepoint's own two files are no longer adjacent** (positions 3 and 5, split by the deltacommit's completed file at 4), so the inline 2-file savepoint pairing can't group them either.

The bug is silent (logged only at INFO: `Could not create batches with completed commits…`).

Confirmed in staging by cloning Concentric's `lhperftest/.../permissions_bronze/.hoodie/` (5 daily savepoint groups + 1 compaction-with-savepoint) and observing the looping INFO log every poll cycle with no progress.

## Fix
`extractSavepointPairs` records the instant times of all non-savepoint files, then peels a complete savepoint pair (`inflight` + `completed`) into its own 2-file batch **only when its timestamp collides** with a non-savepoint instant. This:
- groups the savepoint's two files by timestamp regardless of adjacency (fixes #2), and
- removes them from the sorted list so the deltacommit triplet becomes contiguous again (fixes #1).

Non-colliding savepoints and partial savepoints (only inflight or only completed) stay in the list and are processed by the existing inline savepoint path, unchanged. Colliding savepoint batches are appended after the commit batches (safe — savepoints carry no write metadata).

## Test plan
- [x] Existing `ActiveTimelineInstantBatcherTest` cases still pass (V1 layout / no savepoints).
- [x] Existing V9 tests still pass.
- [x] Added `testCreateBatchWithV9SavepointSharingInstantTimeWithDeltacommit`, modelled on `permissions_bronze`'s timeline (daily deltacommit+savepoint sharing instant time): reproduces the zero-batches bug and asserts the deltacommit triplets batch cleanly with the savepoint pairs appended. Suite now 25 tests / 0 failures.
- [x] CI build green (build + SonarCloud).
- [ ] Re-run the staging clone of `permissions_bronze` and observe `Uploading batch …` logs progressing past April 30. _(manual staging step)_

## Related
- ENG-41301 — Concentric Lakeview v9 stats missing / 500
- gateway-controller PR #9103 (read-side fixes for the lifecycle sentinel rows that surface from the same incident)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
