### PR TITLE
[ENG-41339] Add docs/ scaffold + CLAUDE.md with documentation upkeep convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# LakeView — Claude Context
+
+## Project Overview
+
+`LakeView` is a OneHouse component for surfacing lakehouse-table observability — table metadata, partition health, ingestion progress, and similar visibility into Hudi/Iceberg tables managed by OneHouse.
+
+## Documentation
+
+All conceptual / architectural / operational docs live in `docs/`. See [`docs/index.md`](docs/index.md) for the index.
+
+This repo's `docs/` folder is mounted into the OneHouse AI agent platform via git-sync and indexed into QMD as the `lakeview-docs` collection — so well-written docs here are directly consumed by RCA, Scoping, and other agents.
+
+## Coding Principles
+
+- **Document everything.** Every new feature, integration, or significant change MUST have corresponding documentation in `docs/`. Create a new doc file if no existing doc covers the topic. Always keep docs in sync with code — documentation is not optional.
+
+- When opening a PR or pushing a commit that touches behaviour, also update the relevant doc under `docs/`. If your change affects architecture, deployment, or configuration, expand or rewrite the corresponding section. If you add a new module or component, add a doc for it.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,17 @@
+# Getting Started
+
+> **Stub.** Engineers will fill this in.
+
+See the existing root-level [README.md](../README.md) for current build/run instructions; this file should grow into a curated developer onboarding guide.
+
+## Prerequisites
+
+> Java/Gradle versions, OneHouse credentials, cloud-storage account access, etc.
+
+## Local Setup
+
+> Clone, configure, build, run.
+
+## Common tasks
+
+> One-liners for the most common dev workflows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,16 @@
+# LakeView Documentation
+
+This directory holds conceptual / architectural / operational documentation for the `LakeView` repo. Code-level docstrings live in source files; long-form explanation lives here.
+
+## Index
+
+- [overview.md](overview.md) — what this repo does and where it fits in the OneHouse stack
+- [getting-started.md](getting-started.md) — local development setup
+
+## Adding a doc
+
+Drop a new `<topic>.md` here and link it in this index.
+
+## Indexing automation
+
+This repo's `docs/` folder is mounted into the OneHouse AI agent platform via git-sync and indexed into QMD as the `lakeview-docs` collection. After landing a doc change on `main`, trigger the [reindex workflow](https://github.com/onehouseinc/knowledge-base/actions/workflows/reindex-qmd.yml) or wait up to an hour for the next git-sync tick.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,14 @@
+# LakeView — Overview
+
+> **Stub.** Engineers will fill this in.
+
+`LakeView` is a OneHouse component for surfacing lakehouse-table observability — table metadata, partition health, ingestion progress, and similar visibility into Hudi/Iceberg tables managed by OneHouse.
+
+## Components
+
+> List key components / modules — typical entries: storage clients (S3/GCS/Azure), metadata extractors, REST/gRPC API layer.
+
+## Related repos
+
+- `onehouse-dataplane` — produces the table state LakeView surfaces
+- `gateway-controller` — control-plane counterpart that LakeView interacts with


### PR DESCRIPTION
## Summary

- Bootstrap the \`docs/\` folder for the OneHouse AI agent platform's QMD-indexing pipeline.
- Add a top-level \`CLAUDE.md\` with the standard documentation upkeep convention.

## Why

The OneHouse AI agent platform git-syncs every repo and indexes each repo's \`docs/\` folder into QMD as a per-repo collection (\`lakeview-docs\`). For the agent's \`query\` MCP to return useful hits about LakeView, this repo needs a top-level \`docs/\` to land into. This PR ships the scaffolding so the collection registers non-empty; engineers will fill in real content over time.

The CLAUDE.md upkeep convention codifies "document everything in \`docs/\`" — same convention being applied across the full OneHouse repo set under ENG-41339.

## Files

- \`CLAUDE.md\` — project overview + documentation upkeep convention
- \`docs/index.md\` — per-repo doc index
- \`docs/overview.md\` — stub
- \`docs/getting-started.md\` — stub
- \`docs/.gitkeep\` — placeholder

## Companion work

This PR is one of several under ENG-41339 across OneHouse repos that all add the same \`docs/\` + CLAUDE.md scaffold. Once these land, the QMD reindex pipeline (in [knowledge-base/.github/workflows/reindex-qmd.yml](https://github.com/onehouseinc/knowledge-base/blob/main/.github/workflows/reindex-qmd.yml)) picks them up and exposes them to the RCA / Scoping agents.

## Test plan

- [ ] After merge: trigger the knowledge-base reindex workflow; confirm \`lakeview-docs\` collection has non-zero docs in \`qmd status\`.