### PR TITLE
Discover and upload Iceberg tables alongside Hudi

### DIFF
--- a/docs/iceberg-support.md
+++ b/docs/iceberg-support.md
@@ -1,0 +1,92 @@
+# Iceberg Table Support
+
+LakeView discovers and uploads metadata for Apache Iceberg tables alongside Hudi tables. For
+Iceberg, the extractor uploads the current `metadata.json` pointer file each iteration; the control
+plane parses the snapshot summary from it (cumulative `total-records`, `total-files-size`,
+`total-data-files`, per-snapshot deltas, and the `snapshot-log[]` history) and writes metrics to
+OpenSearch.
+
+## Table format detection
+
+Format detection is a pluggable SPI, `TableFormatDetector`, with one implementation per format:
+
+- `HudiTableFormatDetector` — a directory is a Hudi table root if it contains a `.hoodie/` folder.
+- `IcebergTableFormatDetector` — a directory is an Iceberg table root if it contains a `metadata/`
+  sub-directory **and** that sub-directory holds at least one `*.metadata.json` pointer file. The
+  pointer-file check separates a real Iceberg table from any folder that merely has a sub-directory
+  named `metadata` (Spark checkpoint dirs, docs folders, etc.). This costs one extra `LIST` per
+  candidate directory during discovery — not per upload cycle.
+
+Detectors are **not raced** against each other. Each `Database` in the parser YAML declares its
+`tableFormat`, and `TableDiscoveryService` selects the single matching detector for every directory
+under that database's base paths.
+
+### Declaring the format in parser YAML
+
+```yaml
+parserConfig:
+  - lake: my_lake
+    databases:
+      - name: my_iceberg_db
+        tableFormat: ICEBERG        # absent / null => HUDI (back-compat)
+        basePaths:
+          - s3://bucket/warehouse/my_iceberg_db/
+```
+
+A mixed-format warehouse should be split into separate `Database` entries, one per format.
+
+## Selecting the current `metadata.json`
+
+`IcebergMetadataUploaderService` resolves the current pointer through three paths, in order of
+preference:
+
+1. **`metadataLocationHint`** — the URI of the current `metadata.json` supplied by the control plane
+   in the parser YAML's `tableHints` (e.g. from AWS Glue's `metadata_location` parameter). When
+   present, the extractor PUTs the file directly and skips the per-cycle `metadata/` listing.
+   *Hints only apply to base paths pinned with an explicit `#tableId`; auto-discovered tables always
+   fall back to listing.*
+2. **`metadata/version-hint.text`** — for Hadoop-catalog tables, its integer content names the
+   current `v{N}.metadata.json` unambiguously.
+3. **Numeric-aware filename comparison** (last resort) — the leading integer in the filename (after
+   an optional `v` prefix) is the version number. Works for both `v{N}.metadata.json` (Hadoop) and
+   `00000-<uuid>.metadata.json` (Hive/Glue/Spark). **Caveat:** the highest-versioned file is not
+   guaranteed to be the catalog's committed pointer — a failed or concurrent write can leave an
+   orphan with a higher version. This is best-effort; paths 1 and 2 are authoritative and preferred
+   for exactly that reason.
+
+The checkpoint tracks the last-uploaded filename; if it hasn't advanced since the last run, the
+iteration is a no-op.
+
+`s3a://` URIs (the Hadoop scheme that Glue/Onehouse-agent `metadata_location` values use) are
+accepted by the storage URI parser in addition to `s3://`.
+
+## Upload orchestration
+
+`TableDiscoveryAndUploadJob.dispatchUpload` partitions discovered tables by format and runs the Hudi
+(`TableMetadataUploaderService`) and Iceberg (`IcebergMetadataUploaderService`) uploaders
+concurrently. A `null` table format is treated as `HUDI`. `IcebergMetadataUploaderService` is a
+sibling of the Hudi uploader rather than a subclass — Hudi's active/archived timeline distinction,
+`hoodie.properties` bootstrap, and LSM manifest plumbing don't apply to Iceberg — but it reuses the
+shared `OnehouseApiClient`, `PresignedUrlFileUploader`, `AsyncStorageClient`, and `StorageUtils`.
+
+On the init RPC (`InitializeTableMetricsCheckpoint`), Iceberg tables send `tableFormat=ICEBERG` and
+a placeholder `tableType=COPY_ON_WRITE` (the server discriminates on `tableFormat` first; `tableType`
+is meaningless for Iceberg but stays non-null to preserve the wire contract).
+
+## Deployment ordering
+
+⚠️ This feature spans three repositories and **must be rolled out in order**:
+
+1. **idls** — adds the `TableFormat` proto enum / `TableMetricsCheckpoint` field
+   ([idls PR #1939](https://github.com/onehouseinc/idls/pull/1939)).
+2. **gateway-controller** — adds `IcebergCommitMetadataParser` to parse the uploaded `metadata.json`
+   and emit metrics to OpenSearch.
+3. **LakeView** (this repo) — discovers Iceberg tables and uploads `metadata.json`.
+
+If LakeView ships **before** the server understands `tableFormat`, the server-side protobuf JSON
+parser drops the unknown enum value and persists the proto enum-zero default
+(`TABLE_FORMAT_INVALID`), routing Iceberg uploads through the Hudi back-compat fallback — i.e. the
+control plane tries to parse an Iceberg `metadata.json` as a Hudi commit. **Before deploying
+LakeView, confirm the running control plane tolerates `tableFormat=ICEBERG` cleanly** (errors or
+ignores rather than corrupting the checkpoint), and deploy the idls + gateway-controller changes
+first.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ This directory holds conceptual / architectural / operational documentation for 
 
 - [overview.md](overview.md) — what this repo does and where it fits in the OneHouse stack
 - [getting-started.md](getting-started.md) — local development setup
+- [iceberg-support.md](iceberg-support.md) — Iceberg table discovery, metadata.json selection, and deploy ordering
 
 ## Adding a doc
 

--- a/lakeview-sync-tool/src/main/java/ai/onehouse/lakeview/sync/LakeviewSyncTool.java
+++ b/lakeview-sync-tool/src/main/java/ai/onehouse/lakeview/sync/LakeviewSyncTool.java
@@ -257,7 +257,8 @@ public class LakeviewSyncTool extends HoodieSyncTool implements AutoCloseable {
 
     TableDiscoveryService tableDiscoveryService = new TableDiscoveryService(asyncStorageClient, storageUtils,
             configProvider, executorService, lakeViewExtractorMetrics,
-            new HudiTableFormatDetector(), new IcebergTableFormatDetector());
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector(asyncStorageClient, storageUtils));
     HoodiePropertiesReader hoodiePropertiesReader = new HoodiePropertiesReader(asyncStorageClient,
         lakeViewExtractorMetrics);
     OnehouseApiClient onehouseApiClient = new OnehouseApiClient(asyncHttpClientWithRetry, config,

--- a/lakeview-sync-tool/src/main/java/ai/onehouse/lakeview/sync/LakeviewSyncTool.java
+++ b/lakeview-sync-tool/src/main/java/ai/onehouse/lakeview/sync/LakeviewSyncTool.java
@@ -14,6 +14,9 @@ import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.config.models.configv1.ParserConfig;
 import ai.onehouse.metadata_extractor.ActiveTimelineInstantBatcher;
 import ai.onehouse.metadata_extractor.HoodiePropertiesReader;
+import ai.onehouse.metadata_extractor.HudiTableFormatDetector;
+import ai.onehouse.metadata_extractor.IcebergMetadataUploaderService;
+import ai.onehouse.metadata_extractor.IcebergTableFormatDetector;
 import ai.onehouse.metadata_extractor.LSMTimelineManifestReader;
 import ai.onehouse.metadata_extractor.TableDiscoveryAndUploadJob;
 import ai.onehouse.metadata_extractor.TableDiscoveryService;
@@ -253,7 +256,8 @@ public class LakeviewSyncTool extends HoodieSyncTool implements AutoCloseable {
         configProvider);
 
     TableDiscoveryService tableDiscoveryService = new TableDiscoveryService(asyncStorageClient, storageUtils,
-            configProvider, executorService, lakeViewExtractorMetrics);
+            configProvider, executorService, lakeViewExtractorMetrics,
+            new HudiTableFormatDetector(), new IcebergTableFormatDetector());
     HoodiePropertiesReader hoodiePropertiesReader = new HoodiePropertiesReader(asyncStorageClient,
         lakeViewExtractorMetrics);
     OnehouseApiClient onehouseApiClient = new OnehouseApiClient(asyncHttpClientWithRetry, config,
@@ -267,8 +271,11 @@ public class LakeviewSyncTool extends HoodieSyncTool implements AutoCloseable {
         lakeViewExtractorMetrics, config, lsmTimelineManifestReader);
     TableMetadataUploaderService tableMetadataUploaderService = new TableMetadataUploaderService(hoodiePropertiesReader,
         onehouseApiClient, timelineCommitInstantsUploader, lakeViewExtractorMetrics, executorService);
+    IcebergMetadataUploaderService icebergMetadataUploaderService = new IcebergMetadataUploaderService(
+        asyncStorageClient, onehouseApiClient, presignedUrlFileUploader, storageUtils, lakeViewExtractorMetrics);
 
-    return new TableDiscoveryAndUploadJob(tableDiscoveryService, tableMetadataUploaderService, lakeViewExtractorMetrics, asyncStorageClient);
+    return new TableDiscoveryAndUploadJob(tableDiscoveryService, tableMetadataUploaderService,
+        icebergMetadataUploaderService, lakeViewExtractorMetrics, asyncStorageClient);
   }
 
   private AsyncStorageClient getAsyncStorageClient(@Nonnull Config config, @Nonnull ExecutorService executorService,

--- a/lakeview/src/main/java/ai/onehouse/api/models/request/InitializeTableMetricsCheckpointRequest.java
+++ b/lakeview/src/main/java/ai/onehouse/api/models/request/InitializeTableMetricsCheckpointRequest.java
@@ -21,7 +21,13 @@ public class InitializeTableMetricsCheckpointRequest {
   public static class InitializeSingleTableMetricsCheckpointRequest {
     @NonNull String tableId;
     @NonNull String tableName;
+    // For Hudi: source of truth for COW vs MOR. For non-Hudi formats it is a meaningless
+    // placeholder; the server discriminates on tableFormat first. Kept non-null to preserve
+    // the existing wire contract; defaults to COPY_ON_WRITE for Iceberg tables.
     @NonNull TableType tableType;
+    // Physical table format. Absent is interpreted by the server as HUDI for backward compat
+    // with extractors that haven't been updated.
+    @Nullable TableFormat tableFormat;
     String lakeName;
     String databaseName;
     String tableBasePath;

--- a/lakeview/src/main/java/ai/onehouse/api/models/request/TableFormat.java
+++ b/lakeview/src/main/java/ai/onehouse/api/models/request/TableFormat.java
@@ -1,6 +1,20 @@
 package ai.onehouse.api.models.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Physical observed-table format. Wire-serialized to the protobuf enum names defined in
+ * lake/table.proto's {@code TableFormat} so the control plane's protobuf-java-util JSON parser
+ * accepts the value on RPCs like {@code InitializeTableMetricsCheckpoint}. Without these
+ * {@code @JsonProperty} aliases, Jackson would emit the short Java identifier ({@code "ICEBERG"})
+ * and the server-side parser — which requires the canonical proto enum name
+ * ({@code "TABLE_FORMAT_ICEBERG"}) — would silently drop the value and persist the checkpoint
+ * with the proto enum-zero default ({@code TABLE_FORMAT_INVALID}), routing iceberg uploads
+ * through the Hudi back-compat fallback.
+ */
 public enum TableFormat {
+  @JsonProperty("TABLE_FORMAT_HUDI")
   HUDI,
+  @JsonProperty("TABLE_FORMAT_ICEBERG")
   ICEBERG
 }

--- a/lakeview/src/main/java/ai/onehouse/api/models/request/TableFormat.java
+++ b/lakeview/src/main/java/ai/onehouse/api/models/request/TableFormat.java
@@ -1,0 +1,6 @@
+package ai.onehouse.api.models.request;
+
+public enum TableFormat {
+  HUDI,
+  ICEBERG
+}

--- a/lakeview/src/main/java/ai/onehouse/config/models/configv1/Database.java
+++ b/lakeview/src/main/java/ai/onehouse/config/models/configv1/Database.java
@@ -1,6 +1,8 @@
 package ai.onehouse.config.models.configv1;
 
 import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -12,4 +14,12 @@ import lombok.extern.jackson.Jacksonized;
 public class Database {
   String name;
   @NonNull List<String> basePaths;
+  /**
+   * Optional per-table hints keyed on the tableId encoded in {@link #basePaths} (the segment after
+   * {@code #}). The control plane populates this for tables it has richer information about
+   * (e.g. Iceberg tables discovered via AWS Glue, where the catalog already knows the current
+   * {@code metadata.json} URI). Missing entries / missing map are normal — older YAML versions
+   * predate this field, and tables without hints fall back to plain discovery.
+   */
+  @Nullable Map<String, TableHint> tableHints;
 }

--- a/lakeview/src/main/java/ai/onehouse/config/models/configv1/Database.java
+++ b/lakeview/src/main/java/ai/onehouse/config/models/configv1/Database.java
@@ -1,5 +1,6 @@
 package ai.onehouse.config.models.configv1;
 
+import ai.onehouse.api.models.request.TableFormat;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -14,6 +15,13 @@ import lombok.extern.jackson.Jacksonized;
 public class Database {
   String name;
   @NonNull List<String> basePaths;
+  /**
+   * Physical table format of the tables under {@link #basePaths}. Null is interpreted as {@link
+   * TableFormat#HUDI} for backward compatibility with YAMLs written before Iceberg support
+   * existed. Customers with a mixed-format warehouse should split into separate {@link Database}
+   * entries, one per format.
+   */
+  @Nullable TableFormat tableFormat;
   /**
    * Optional per-table hints keyed on the tableId encoded in {@link #basePaths} (the segment after
    * {@code #}). The control plane populates this for tables it has richer information about

--- a/lakeview/src/main/java/ai/onehouse/config/models/configv1/TableHint.java
+++ b/lakeview/src/main/java/ai/onehouse/config/models/configv1/TableHint.java
@@ -1,0 +1,24 @@
+package ai.onehouse.config.models.configv1;
+
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * Optional per-table hints supplied by the control plane in the parser YAML, keyed on tableId in
+ * {@link Database#getTableHints()}. Hints are forward-compatible: older LakeView versions that
+ * don't know about a field deserialize the rest fine; new fields default to null.
+ */
+@Builder
+@Value
+@Jacksonized
+public class TableHint {
+  /**
+   * For Iceberg tables registered in an external catalog (e.g. AWS Glue), the URI of the current
+   * {@code metadata.json} that the catalog points at. When present, the extractor can PUT this
+   * file directly instead of listing the {@code metadata/} folder to find the latest. Empty /
+   * null means "no hint — fall back to listing".
+   */
+  @Nullable String metadataLocationHint;
+}

--- a/lakeview/src/main/java/ai/onehouse/constants/MetadataExtractorConstants.java
+++ b/lakeview/src/main/java/ai/onehouse/constants/MetadataExtractorConstants.java
@@ -16,6 +16,8 @@ public class MetadataExtractorConstants {
   public static final String ARCHIVED_FOLDER_NAME = "archived";
   public static final String ICEBERG_METADATA_FOLDER_NAME = "metadata";
   public static final String ICEBERG_METADATA_FILE_SUFFIX = ".metadata.json";
+  public static final String ICEBERG_VERSION_HINT_FILENAME = "version-hint.text";
+  public static final String ICEBERG_HADOOP_METADATA_FILE_PREFIX = "v";
   public static final String HOODIE_PROPERTIES_FILE = "hoodie.properties";
   public static final String HOODIE_TABLE_NAME_KEY = "hoodie.table.name";
   public static final String HOODIE_TABLE_TYPE_KEY = "hoodie.table.type";

--- a/lakeview/src/main/java/ai/onehouse/constants/MetadataExtractorConstants.java
+++ b/lakeview/src/main/java/ai/onehouse/constants/MetadataExtractorConstants.java
@@ -14,6 +14,8 @@ public class MetadataExtractorConstants {
 
   public static final String HOODIE_FOLDER_NAME = ".hoodie";
   public static final String ARCHIVED_FOLDER_NAME = "archived";
+  public static final String ICEBERG_METADATA_FOLDER_NAME = "metadata";
+  public static final String ICEBERG_METADATA_FILE_SUFFIX = ".metadata.json";
   public static final String HOODIE_PROPERTIES_FILE = "hoodie.properties";
   public static final String HOODIE_TABLE_NAME_KEY = "hoodie.table.name";
   public static final String HOODIE_TABLE_TYPE_KEY = "hoodie.table.type";

--- a/lakeview/src/main/java/ai/onehouse/constants/StorageConstants.java
+++ b/lakeview/src/main/java/ai/onehouse/constants/StorageConstants.java
@@ -7,13 +7,15 @@ public class StorageConstants {
 
   /*
   * typical s3 path: "s3://bucket-name/path/to/object"
+  * hadoop-style s3 path: "s3a://bucket-name/path/to/object" (e.g. iceberg metadata_location entries
+  *   stamped by Glue/Onehouse agent — see gateway-controller commit 0761ef368d)
   * gcs path format: "gs://bucket/path/to/file"
   * azure blob format: "https://account.blob.core.windows.net/container/path/to/blob"
   * azure adls gen2 format: "https://account.dfs.core.windows.net/container/path/to/file"
   * azure adls gen2 abfss format: "abfss://container@account.dfs.core.windows.net/path/to/file"
   */
   public static final Pattern OBJECT_STORAGE_URI_PATTERN =
-      Pattern.compile("^(?:(s3://|gs://|abfss://)|https://[^.]+\\.(?:blob|dfs)\\.core\\.windows\\.net/)([^/@]+)(?:@[^/]+)?(/.*)?$");
+      Pattern.compile("^(?:(s3a?://|gs://|abfss://)|https://[^.]+\\.(?:blob|dfs)\\.core\\.windows\\.net/)([^/@]+)(?:@[^/]+)?(/.*)?$");
 
   // https://cloud.google.com/compute/docs/naming-resources#resource-name-format
   public static final String GCP_RESOURCE_NAME_FORMAT = "^[a-z]([-a-z0-9]*[a-z0-9])$";

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/HudiTableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/HudiTableFormatDetector.java
@@ -1,0 +1,20 @@
+package ai.onehouse.metadata_extractor;
+
+import static ai.onehouse.constants.MetadataExtractorConstants.HOODIE_FOLDER_NAME;
+
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.models.File;
+import java.util.List;
+
+/** A directory is a Hudi table root if it contains a {@code .hoodie/} folder. */
+public class HudiTableFormatDetector implements TableFormatDetector {
+  @Override
+  public TableFormat format() {
+    return TableFormat.HUDI;
+  }
+
+  @Override
+  public boolean matches(List<File> listedFiles) {
+    return listedFiles.stream().anyMatch(file -> file.getFilename().startsWith(HOODIE_FOLDER_NAME));
+  }
+}

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/HudiTableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/HudiTableFormatDetector.java
@@ -5,6 +5,7 @@ import static ai.onehouse.constants.MetadataExtractorConstants.HOODIE_FOLDER_NAM
 import ai.onehouse.api.models.request.TableFormat;
 import ai.onehouse.storage.models.File;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /** A directory is a Hudi table root if it contains a {@code .hoodie/} folder. */
 public class HudiTableFormatDetector implements TableFormatDetector {
@@ -14,7 +15,8 @@ public class HudiTableFormatDetector implements TableFormatDetector {
   }
 
   @Override
-  public boolean matches(List<File> listedFiles) {
-    return listedFiles.stream().anyMatch(file -> file.getFilename().startsWith(HOODIE_FOLDER_NAME));
+  public CompletableFuture<Boolean> matches(String path, List<File> listedFiles) {
+    return CompletableFuture.completedFuture(
+        listedFiles.stream().anyMatch(file -> file.getFilename().startsWith(HOODIE_FOLDER_NAME)));
   }
 }

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
@@ -186,6 +186,30 @@ public class IcebergMetadataUploaderService {
   }
 
   private CompletableFuture<Boolean> uploadIfNewMetadataJson(Table table, Checkpoint checkpoint) {
+    // Fast path: control plane provided the current metadata.json URI (e.g. from AWS Glue's
+    // metadata_location parameter). Skip the per-cycle LIST and PUT the file directly.
+    if (StringUtils.isNotBlank(table.getMetadataLocationHint())) {
+      String hint = table.getMetadataLocationHint();
+      String filename = lastPathSegment(hint);
+      if (filename.equals(checkpoint.getLastUploadedFile())) {
+        log.debug(
+            "Iceberg table {} already up-to-date at {} (from hint)",
+            table.getTableId(),
+            filename);
+        return CompletableFuture.completedFuture(true);
+      }
+      File synthetic =
+          File.builder()
+              .filename(filename)
+              .isDirectory(false)
+              // Hint doesn't carry lastModifiedAt; use now() since it's only used for ordering
+              // on the consumer side and is not load-bearing for correctness.
+              .lastModifiedAt(Instant.now())
+              .build();
+      return uploadAndAdvanceCheckpoint(table, hint, synthetic, checkpoint);
+    }
+
+    // Fallback path: list metadata/ and lex-sort.
     String metadataDirUri =
         storageUtils.constructFileUri(table.getAbsoluteTableUri(), ICEBERG_METADATA_FOLDER_NAME);
     return asyncStorageClient
@@ -207,13 +231,14 @@ public class IcebergMetadataUploaderService {
                     latest.get().getFilename());
                 return CompletableFuture.completedFuture(true);
               }
-              return uploadAndAdvanceCheckpoint(table, metadataDirUri, latest.get(), checkpoint);
+              String fileUri =
+                  storageUtils.constructFileUri(metadataDirUri, latest.get().getFilename());
+              return uploadAndAdvanceCheckpoint(table, fileUri, latest.get(), checkpoint);
             });
   }
 
   private CompletableFuture<Boolean> uploadAndAdvanceCheckpoint(
-      Table table, String metadataDirUri, File metadataJson, Checkpoint priorCheckpoint) {
-    String fileUri = storageUtils.constructFileUri(metadataDirUri, metadataJson.getFilename());
+      Table table, String fileUri, File metadataJson, Checkpoint priorCheckpoint) {
     return onehouseApiClient
         .generateCommitMetadataUploadUrl(
             GenerateCommitMetadataUploadUrlRequest.builder()
@@ -301,6 +326,11 @@ public class IcebergMetadataUploaderService {
         .filter(f -> !f.isDirectory())
         .filter(f -> f.getFilename().endsWith(ICEBERG_METADATA_FILE_SUFFIX))
         .max((a, b) -> a.getFilename().compareTo(b.getFilename()));
+  }
+
+  static String lastPathSegment(String uri) {
+    int idx = uri.lastIndexOf('/');
+    return idx < 0 ? uri : uri.substring(idx + 1);
   }
 
   private static String deriveTableName(String basePathUri) {

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
@@ -1,11 +1,14 @@
 package ai.onehouse.metadata_extractor;
 
 import static ai.onehouse.constants.MetadataExtractorConstants.DEFAULT_FILE_UPLOAD_STREAM_BATCH_SIZE;
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_HADOOP_METADATA_FILE_PREFIX;
 import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FILE_SUFFIX;
 import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FOLDER_NAME;
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_VERSION_HINT_FILENAME;
 import static ai.onehouse.constants.MetadataExtractorConstants.INITIAL_CHECKPOINT;
 import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataExtractorFailureReason;
 
+import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
 import ai.onehouse.api.OnehouseApiClient;
 import ai.onehouse.api.models.request.CommitTimelineType;
 import ai.onehouse.api.models.request.GenerateCommitMetadataUploadUrlRequest;
@@ -15,7 +18,6 @@ import ai.onehouse.api.models.request.TableFormat;
 import ai.onehouse.api.models.request.TableType;
 import ai.onehouse.api.models.request.UploadedFile;
 import ai.onehouse.api.models.request.UpsertTableMetricsCheckpointRequest;
-import ai.onehouse.api.models.response.GenerateCommitMetadataUploadUrlResponse;
 import ai.onehouse.api.models.response.GetTableMetricsCheckpointResponse;
 import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.metadata_extractor.models.Checkpoint;
@@ -25,13 +27,14 @@ import ai.onehouse.storage.AsyncStorageClient;
 import ai.onehouse.storage.PresignedUrlFileUploader;
 import ai.onehouse.storage.StorageUtils;
 import ai.onehouse.storage.models.File;
-import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.inject.Inject;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -55,6 +58,17 @@ import org.apache.commons.lang3.StringUtils;
  * manifest plumbing don't apply, so a separate service is clearer than a branching megaclass.
  * Shared primitives ({@link OnehouseApiClient}, {@link PresignedUrlFileUploader}, {@link
  * AsyncStorageClient}) are reused.
+ *
+ * <p><b>Selecting the current pointer.</b> Three paths, in order of preference:
+ * <ol>
+ *   <li>{@link Table#getMetadataLocationHint()} from the parser YAML (catalog-driven).</li>
+ *   <li>{@code metadata/version-hint.text} for Hadoop-catalog tables — its integer content names
+ *       the current {@code v{N}.metadata.json} unambiguously.</li>
+ *   <li>Numeric-aware filename comparison as a last resort. The leading integer in the filename
+ *       (after an optional {@code v} prefix) is treated as the version number. Works for both
+ *       {@code v{N}.metadata.json} (Hadoop) and {@code 00000-<uuid>.metadata.json}
+ *       (Hive/Glue/Spark) without depending on zero-padding.</li>
+ * </ol>
  */
 @Slf4j
 public class IcebergMetadataUploaderService {
@@ -202,39 +216,98 @@ public class IcebergMetadataUploaderService {
           File.builder()
               .filename(filename)
               .isDirectory(false)
-              // Hint doesn't carry lastModifiedAt; use now() since it's only used for ordering
-              // on the consumer side and is not load-bearing for correctness.
+              // Hint doesn't carry lastModifiedAt; use now() since the consumer treats this as
+              // advisory and discriminates by checkpoint batchId for ordering.
               .lastModifiedAt(Instant.now())
               .build();
       return uploadAndAdvanceCheckpoint(table, hint, synthetic, checkpoint);
     }
 
-    // Fallback path: list metadata/ and lex-sort.
+    // Fallback path: list metadata/, prefer version-hint.text, else numeric-aware sort.
     String metadataDirUri =
         storageUtils.constructFileUri(table.getAbsoluteTableUri(), ICEBERG_METADATA_FOLDER_NAME);
     return asyncStorageClient
         .listAllFilesInDir(metadataDirUri)
         .thenComposeAsync(
-            files -> {
-              Optional<File> latest = pickLatestMetadataJson(files);
-              if (!latest.isPresent()) {
-                log.warn(
-                    "Iceberg table {} has no metadata.json under {}",
-                    table.getTableId(),
-                    metadataDirUri);
-                return CompletableFuture.completedFuture(true);
+            files ->
+                resolveLatestMetadataJson(metadataDirUri, files)
+                    .thenComposeAsync(
+                        latestOpt -> {
+                          if (!latestOpt.isPresent()) {
+                            log.error(
+                                "Iceberg table {} has no *.metadata.json under {}",
+                                table.getTableId(),
+                                metadataDirUri);
+                            metrics.incrementTableMetadataProcessingFailureCounter(
+                                MetricsConstants.MetadataUploadFailureReasons.NO_SUCH_KEY,
+                                "Iceberg table missing metadata.json files");
+                            return CompletableFuture.completedFuture(false);
+                          }
+                          File latest = latestOpt.get();
+                          if (latest.getFilename().equals(checkpoint.getLastUploadedFile())) {
+                            log.debug(
+                                "Iceberg table {} already up-to-date at {}",
+                                table.getTableId(),
+                                latest.getFilename());
+                            return CompletableFuture.completedFuture(true);
+                          }
+                          String fileUri =
+                              storageUtils.constructFileUri(metadataDirUri, latest.getFilename());
+                          return uploadAndAdvanceCheckpoint(table, fileUri, latest, checkpoint);
+                        }));
+  }
+
+  /**
+   * Resolves the current {@code metadata.json} given a listing of {@code metadata/}. Reads
+   * {@code version-hint.text} when present and falls back to numeric-aware filename comparison
+   * otherwise.
+   */
+  private CompletableFuture<Optional<File>> resolveLatestMetadataJson(
+      String metadataDirUri, List<File> files) {
+    Optional<File> versionHintFile =
+        files.stream()
+            .filter(f -> !f.isDirectory() && ICEBERG_VERSION_HINT_FILENAME.equals(f.getFilename()))
+            .findFirst();
+    if (!versionHintFile.isPresent()) {
+      return CompletableFuture.completedFuture(pickLatestMetadataJson(files));
+    }
+    String hintUri = storageUtils.constructFileUri(metadataDirUri, ICEBERG_VERSION_HINT_FILENAME);
+    return asyncStorageClient
+        .readFileAsBytes(hintUri)
+        .thenApply(
+            bytes -> {
+              Optional<File> fromHint = resolveFromVersionHint(bytes, files);
+              if (fromHint.isPresent()) {
+                return fromHint;
               }
-              if (latest.get().getFilename().equals(checkpoint.getLastUploadedFile())) {
-                log.debug(
-                    "Iceberg table {} already up-to-date at {}",
-                    table.getTableId(),
-                    latest.get().getFilename());
-                return CompletableFuture.completedFuture(true);
-              }
-              String fileUri =
-                  storageUtils.constructFileUri(metadataDirUri, latest.get().getFilename());
-              return uploadAndAdvanceCheckpoint(table, fileUri, latest.get(), checkpoint);
+              log.warn(
+                  "version-hint.text at {} did not point at an existing metadata.json; falling back to numeric sort",
+                  hintUri);
+              return pickLatestMetadataJson(files);
+            })
+        .exceptionally(
+            ex -> {
+              log.warn(
+                  "Failed to read version-hint.text at {}; falling back to numeric sort",
+                  hintUri,
+                  ex);
+              return pickLatestMetadataJson(files);
             });
+  }
+
+  static Optional<File> resolveFromVersionHint(byte[] versionHintBytes, List<File> files) {
+    String content = new String(versionHintBytes, StandardCharsets.UTF_8).trim();
+    long version;
+    try {
+      version = Long.parseLong(content);
+    } catch (NumberFormatException e) {
+      log.warn("version-hint.text contained non-integer content: '{}'", content);
+      return Optional.empty();
+    }
+    String target = ICEBERG_HADOOP_METADATA_FILE_PREFIX + version + ICEBERG_METADATA_FILE_SUFFIX;
+    return files.stream()
+        .filter(f -> !f.isDirectory() && target.equals(f.getFilename()))
+        .findFirst();
   }
 
   private CompletableFuture<Boolean> uploadAndAdvanceCheckpoint(
@@ -317,15 +390,55 @@ public class IcebergMetadataUploaderService {
   }
 
   /**
-   * Picks the latest metadata.json from a {@code metadata/} listing. Both naming conventions in
-   * use today — {@code v{N}.metadata.json} (Hadoop catalog) and {@code 00000-<uuid>.metadata.json}
-   * (Hive / Glue / Spark) — sort to the same answer lexicographically.
+   * Picks the latest {@code *.metadata.json} from a {@code metadata/} listing using numeric-aware
+   * comparison. The leading integer in the filename (after an optional {@code v} prefix) is the
+   * version number; ties fall back to lexicographic order on the full filename so the result is
+   * deterministic.
+   *
+   * <p>Examples:
+   * <ul>
+   *   <li>{@code v1.metadata.json}, {@code v10.metadata.json}, {@code v2.metadata.json} →
+   *       {@code v10.metadata.json}</li>
+   *   <li>{@code 00001-a.metadata.json}, {@code 00010-b.metadata.json} →
+   *       {@code 00010-b.metadata.json}</li>
+   * </ul>
    */
   static Optional<File> pickLatestMetadataJson(List<File> files) {
+    Comparator<File> byVersionThenName =
+        Comparator.<File>comparingLong(f -> extractVersionNumber(f.getFilename()))
+            .thenComparing(File::getFilename);
     return files.stream()
         .filter(f -> !f.isDirectory())
         .filter(f -> f.getFilename().endsWith(ICEBERG_METADATA_FILE_SUFFIX))
-        .max((a, b) -> a.getFilename().compareTo(b.getFilename()));
+        .max(byVersionThenName);
+  }
+
+  /**
+   * Extracts the leading integer "version number" from an Iceberg metadata-json filename. Returns
+   * {@code -1} when no integer prefix is present (the file still participates in ordering — it
+   * just loses any tiebreak with numerically-named siblings).
+   */
+  static long extractVersionNumber(String filename) {
+    String base =
+        filename.endsWith(ICEBERG_METADATA_FILE_SUFFIX)
+            ? filename.substring(0, filename.length() - ICEBERG_METADATA_FILE_SUFFIX.length())
+            : filename;
+    int i = 0;
+    if (i < base.length() && base.charAt(i) == 'v') {
+      i++;
+    }
+    int start = i;
+    while (i < base.length() && Character.isDigit(base.charAt(i))) {
+      i++;
+    }
+    if (i == start) {
+      return -1L;
+    }
+    try {
+      return Long.parseLong(base.substring(start, i));
+    } catch (NumberFormatException e) {
+      return -1L;
+    }
   }
 
   static String lastPathSegment(String uri) {

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
@@ -1,0 +1,311 @@
+package ai.onehouse.metadata_extractor;
+
+import static ai.onehouse.constants.MetadataExtractorConstants.DEFAULT_FILE_UPLOAD_STREAM_BATCH_SIZE;
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FILE_SUFFIX;
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FOLDER_NAME;
+import static ai.onehouse.constants.MetadataExtractorConstants.INITIAL_CHECKPOINT;
+import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataExtractorFailureReason;
+
+import ai.onehouse.api.OnehouseApiClient;
+import ai.onehouse.api.models.request.CommitTimelineType;
+import ai.onehouse.api.models.request.GenerateCommitMetadataUploadUrlRequest;
+import ai.onehouse.api.models.request.InitializeTableMetricsCheckpointRequest;
+import ai.onehouse.api.models.request.InitializeTableMetricsCheckpointRequest.InitializeSingleTableMetricsCheckpointRequest;
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.api.models.request.TableType;
+import ai.onehouse.api.models.request.UploadedFile;
+import ai.onehouse.api.models.request.UpsertTableMetricsCheckpointRequest;
+import ai.onehouse.api.models.response.GenerateCommitMetadataUploadUrlResponse;
+import ai.onehouse.api.models.response.GetTableMetricsCheckpointResponse;
+import ai.onehouse.constants.MetricsConstants;
+import ai.onehouse.metadata_extractor.models.Checkpoint;
+import ai.onehouse.metadata_extractor.models.Table;
+import ai.onehouse.metrics.LakeViewExtractorMetrics;
+import ai.onehouse.storage.AsyncStorageClient;
+import ai.onehouse.storage.PresignedUrlFileUploader;
+import ai.onehouse.storage.StorageUtils;
+import ai.onehouse.storage.models.File;
+import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.inject.Inject;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Discovers and uploads Iceberg table metadata pointer files ({@code metadata/*.metadata.json}).
+ *
+ * <p>Iceberg's snapshot-summary contract means a single {@code metadata.json} contains all of:
+ * cumulative {@code total-records}, {@code total-files-size}, {@code total-data-files},
+ * per-snapshot deltas, and {@code snapshot-log[]} history. We therefore upload exactly one file
+ * per iteration — the latest {@code metadata.json}. The control plane parses snapshot summaries
+ * from it and writes metrics to OpenSearch.
+ *
+ * <p>Parallel to {@link TableMetadataUploaderService} (the Hudi orchestrator) rather than a
+ * subclass: Hudi's active/archived timeline distinction, hoodie.properties bootstrap, and LSM
+ * manifest plumbing don't apply, so a separate service is clearer than a branching megaclass.
+ * Shared primitives ({@link OnehouseApiClient}, {@link PresignedUrlFileUploader}, {@link
+ * AsyncStorageClient}) are reused.
+ */
+@Slf4j
+public class IcebergMetadataUploaderService {
+  private final AsyncStorageClient asyncStorageClient;
+  private final OnehouseApiClient onehouseApiClient;
+  private final PresignedUrlFileUploader presignedUrlFileUploader;
+  private final StorageUtils storageUtils;
+  private final LakeViewExtractorMetrics metrics;
+  private final ObjectMapper mapper;
+
+  @Inject
+  public IcebergMetadataUploaderService(
+      @Nonnull @TableDiscoveryObjectStorageAsyncClient AsyncStorageClient asyncStorageClient,
+      @Nonnull OnehouseApiClient onehouseApiClient,
+      @Nonnull PresignedUrlFileUploader presignedUrlFileUploader,
+      @Nonnull StorageUtils storageUtils,
+      @Nonnull LakeViewExtractorMetrics metrics) {
+    this.asyncStorageClient = asyncStorageClient;
+    this.onehouseApiClient = onehouseApiClient;
+    this.presignedUrlFileUploader = presignedUrlFileUploader;
+    this.storageUtils = storageUtils;
+    this.metrics = metrics;
+    this.mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+  }
+
+  /**
+   * Uploads the latest metadata.json for each Iceberg table whose pointer file has advanced since
+   * the last checkpoint. Returns true only if every table either succeeded or was already
+   * up-to-date.
+   */
+  public CompletableFuture<Boolean> uploadInstantsInTables(Set<Table> tables) {
+    if (tables.isEmpty()) {
+      return CompletableFuture.completedFuture(true);
+    }
+    log.info("Uploading Iceberg metadata for {} table(s)", tables.size());
+    List<CompletableFuture<Boolean>> perTable =
+        tables.stream().map(this::processTable).collect(Collectors.toList());
+    return CompletableFuture.allOf(perTable.toArray(new CompletableFuture[0]))
+        .thenApply(
+            ignored -> perTable.stream().map(CompletableFuture::join).allMatch(Boolean.TRUE::equals));
+  }
+
+  private CompletableFuture<Boolean> processTable(Table table) {
+    return onehouseApiClient
+        .getTableMetricsCheckpoints(Collections.singletonList(table.getTableId()))
+        .thenComposeAsync(
+            response -> {
+              if (response.isFailure()) {
+                log.error(
+                    "Failed to fetch checkpoint for Iceberg table {} (status {}): {}",
+                    table.getTableId(),
+                    response.getStatusCode(),
+                    response.getCause());
+                return CompletableFuture.completedFuture(false);
+              }
+              Optional<Checkpoint> existing = parseCheckpoint(response, table.getTableId());
+              if (existing.isPresent()) {
+                return uploadIfNewMetadataJson(table, existing.get());
+              }
+              return initialiseTable(table)
+                  .thenComposeAsync(
+                      initOk -> {
+                        if (!initOk) {
+                          return CompletableFuture.completedFuture(false);
+                        }
+                        return uploadIfNewMetadataJson(table, INITIAL_CHECKPOINT);
+                      });
+            })
+        .exceptionally(
+            e -> {
+              log.error("Exception processing Iceberg table {}", table.getTableId(), e);
+              metrics.incrementTableMetadataProcessingFailureCounter(
+                  getMetadataExtractorFailureReason(
+                      e, MetricsConstants.MetadataUploadFailureReasons.UNKNOWN),
+                  String.format("Iceberg upload exception: %s", e.getMessage()));
+              return false;
+            });
+  }
+
+  private Optional<Checkpoint> parseCheckpoint(
+      GetTableMetricsCheckpointResponse response, String tableId) {
+    return response.getCheckpoints().stream()
+        .filter(c -> tableId.equals(c.getTableId()))
+        .findFirst()
+        .map(GetTableMetricsCheckpointResponse.TableMetadataCheckpoint::getCheckpoint)
+        .filter(StringUtils::isNotBlank)
+        .map(
+            json -> {
+              try {
+                return mapper.readValue(json, Checkpoint.class);
+              } catch (JsonProcessingException e) {
+                log.error("Malformed checkpoint JSON for Iceberg table {}; treating as missing", tableId, e);
+                return null;
+              }
+            });
+  }
+
+  private CompletableFuture<Boolean> initialiseTable(Table table) {
+    String tableName = deriveTableName(table.getAbsoluteTableUri());
+    InitializeSingleTableMetricsCheckpointRequest single =
+        InitializeSingleTableMetricsCheckpointRequest.builder()
+            .tableId(table.getTableId())
+            .tableName(tableName)
+            // COW is a meaningless placeholder for Iceberg; server discriminates on tableFormat.
+            .tableType(TableType.COPY_ON_WRITE)
+            .tableFormat(TableFormat.ICEBERG)
+            .lakeName(table.getLakeName())
+            .databaseName(table.getDatabaseName())
+            .tableBasePath(table.getAbsoluteTableUri())
+            .build();
+    return onehouseApiClient
+        .initializeTableMetricsCheckpoint(
+            InitializeTableMetricsCheckpointRequest.builder()
+                .tables(Collections.singletonList(single))
+                .build())
+        .thenApply(
+            initResponse -> {
+              if (initResponse.isFailure()) {
+                log.error(
+                    "Failed to initialise Iceberg table {} (status {}): {}",
+                    table.getTableId(),
+                    initResponse.getStatusCode(),
+                    initResponse.getCause());
+                return false;
+              }
+              return true;
+            });
+  }
+
+  private CompletableFuture<Boolean> uploadIfNewMetadataJson(Table table, Checkpoint checkpoint) {
+    String metadataDirUri =
+        storageUtils.constructFileUri(table.getAbsoluteTableUri(), ICEBERG_METADATA_FOLDER_NAME);
+    return asyncStorageClient
+        .listAllFilesInDir(metadataDirUri)
+        .thenComposeAsync(
+            files -> {
+              Optional<File> latest = pickLatestMetadataJson(files);
+              if (!latest.isPresent()) {
+                log.warn(
+                    "Iceberg table {} has no metadata.json under {}",
+                    table.getTableId(),
+                    metadataDirUri);
+                return CompletableFuture.completedFuture(true);
+              }
+              if (latest.get().getFilename().equals(checkpoint.getLastUploadedFile())) {
+                log.debug(
+                    "Iceberg table {} already up-to-date at {}",
+                    table.getTableId(),
+                    latest.get().getFilename());
+                return CompletableFuture.completedFuture(true);
+              }
+              return uploadAndAdvanceCheckpoint(table, metadataDirUri, latest.get(), checkpoint);
+            });
+  }
+
+  private CompletableFuture<Boolean> uploadAndAdvanceCheckpoint(
+      Table table, String metadataDirUri, File metadataJson, Checkpoint priorCheckpoint) {
+    String fileUri = storageUtils.constructFileUri(metadataDirUri, metadataJson.getFilename());
+    return onehouseApiClient
+        .generateCommitMetadataUploadUrl(
+            GenerateCommitMetadataUploadUrlRequest.builder()
+                .tableId(table.getTableId())
+                .commitInstants(Collections.singletonList(metadataJson.getFilename()))
+                // ACTIVE is a placeholder; Iceberg has no archived/active distinction.
+                .commitTimelineType(CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE)
+                .build())
+        .thenComposeAsync(
+            urlResponse -> {
+              if (urlResponse.isFailure() || urlResponse.getUploadUrls().isEmpty()) {
+                log.error(
+                    "Failed to obtain presigned URL for {} (status {}): {}",
+                    metadataJson.getFilename(),
+                    urlResponse.getStatusCode(),
+                    urlResponse.getCause());
+                return CompletableFuture.completedFuture(false);
+              }
+              String presigned = urlResponse.getUploadUrls().get(0);
+              return presignedUrlFileUploader
+                  .uploadFileToPresignedUrl(presigned, fileUri, DEFAULT_FILE_UPLOAD_STREAM_BATCH_SIZE)
+                  .thenComposeAsync(
+                      ignored -> {
+                        metrics.incrementMetadataUploadSuccessCounter();
+                        return advanceCheckpoint(table, metadataJson, priorCheckpoint);
+                      });
+            });
+  }
+
+  private CompletableFuture<Boolean> advanceCheckpoint(
+      Table table, File metadataJson, Checkpoint priorCheckpoint) {
+    Checkpoint next =
+        priorCheckpoint
+            .toBuilder()
+            .batchId(priorCheckpoint.getBatchId() + 1)
+            .checkpointTimestamp(Instant.now())
+            .lastUploadedFile(metadataJson.getFilename())
+            // Iceberg has no archived/active distinction; mark archived processed so consumers
+            // that interpret the legacy field for ordering don't loop.
+            .archivedCommitsProcessed(true)
+            .build();
+    String checkpointJson;
+    try {
+      checkpointJson = mapper.writeValueAsString(next);
+    } catch (JsonProcessingException e) {
+      log.error("Failed to serialise Iceberg checkpoint for table {}", table.getTableId(), e);
+      return CompletableFuture.completedFuture(false);
+    }
+    UpsertTableMetricsCheckpointRequest request =
+        UpsertTableMetricsCheckpointRequest.builder()
+            .tableId(table.getTableId())
+            .checkpoint(checkpointJson)
+            .filesUploaded(Collections.singletonList(metadataJson.getFilename()))
+            .uploadedFiles(
+                Collections.singletonList(
+                    UploadedFile.builder()
+                        .name(metadataJson.getFilename())
+                        .lastModifiedAt(metadataJson.getLastModifiedAt().toEpochMilli())
+                        .build()))
+            .commitTimelineType(CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE)
+            .build();
+    return onehouseApiClient
+        .upsertTableMetricsCheckpoint(request)
+        .thenApply(
+            upsert -> {
+              if (upsert.isFailure()) {
+                log.error(
+                    "Failed to upsert checkpoint for Iceberg table {} (status {}): {}",
+                    table.getTableId(),
+                    upsert.getStatusCode(),
+                    upsert.getCause());
+                return false;
+              }
+              return true;
+            });
+  }
+
+  /**
+   * Picks the latest metadata.json from a {@code metadata/} listing. Both naming conventions in
+   * use today — {@code v{N}.metadata.json} (Hadoop catalog) and {@code 00000-<uuid>.metadata.json}
+   * (Hive / Glue / Spark) — sort to the same answer lexicographically.
+   */
+  static Optional<File> pickLatestMetadataJson(List<File> files) {
+    return files.stream()
+        .filter(f -> !f.isDirectory())
+        .filter(f -> f.getFilename().endsWith(ICEBERG_METADATA_FILE_SUFFIX))
+        .max((a, b) -> a.getFilename().compareTo(b.getFilename()));
+  }
+
+  private static String deriveTableName(String basePathUri) {
+    String trimmed = basePathUri.endsWith("/") ? basePathUri.substring(0, basePathUri.length() - 1) : basePathUri;
+    int idx = trimmed.lastIndexOf('/');
+    return idx < 0 ? trimmed : trimmed.substring(idx + 1);
+  }
+}

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -109,7 +110,7 @@ public class IcebergMetadataUploaderService {
     }
     log.info("Uploading Iceberg metadata for {} table(s)", tables.size());
     List<CompletableFuture<Boolean>> perTable =
-        tables.stream().map(this::processTable).toList();
+        tables.stream().map(this::processTable).collect(Collectors.toList());
     return CompletableFuture.allOf(perTable.toArray(new CompletableFuture[0]))
         .thenApply(
             ignored -> perTable.stream().map(CompletableFuture::join).allMatch(Boolean.TRUE::equals));

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -58,6 +57,10 @@ import org.apache.commons.lang3.StringUtils;
  * manifest plumbing don't apply, so a separate service is clearer than a branching megaclass.
  * Shared primitives ({@link OnehouseApiClient}, {@link PresignedUrlFileUploader}, {@link
  * AsyncStorageClient}) are reused.
+ *
+ * <p>The {@code thenComposeAsync}/{@code thenApply} stages below intentionally run on the default
+ * fork-join pool: they are non-blocking glue around the already-async storage and API clients, so
+ * a dedicated executor would buy nothing.
  *
  * <p><b>Selecting the current pointer.</b> Three paths, in order of preference:
  * <ol>
@@ -106,7 +109,7 @@ public class IcebergMetadataUploaderService {
     }
     log.info("Uploading Iceberg metadata for {} table(s)", tables.size());
     List<CompletableFuture<Boolean>> perTable =
-        tables.stream().map(this::processTable).collect(Collectors.toList());
+        tables.stream().map(this::processTable).toList();
     return CompletableFuture.allOf(perTable.toArray(new CompletableFuture[0]))
         .thenApply(
             ignored -> perTable.stream().map(CompletableFuture::join).allMatch(Boolean.TRUE::equals));
@@ -123,6 +126,9 @@ public class IcebergMetadataUploaderService {
                     table.getTableId(),
                     response.getStatusCode(),
                     response.getCause());
+                metrics.incrementTableMetadataProcessingFailureCounter(
+                    MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR,
+                    "Failed to fetch checkpoint for Iceberg table");
                 return CompletableFuture.completedFuture(false);
               }
               Optional<Checkpoint> existing = parseCheckpoint(response, table.getTableId());
@@ -132,7 +138,7 @@ public class IcebergMetadataUploaderService {
               return initialiseTable(table)
                   .thenComposeAsync(
                       initOk -> {
-                        if (!initOk) {
+                        if (Boolean.FALSE.equals(initOk)) {
                           return CompletableFuture.completedFuture(false);
                         }
                         return uploadIfNewMetadataJson(table, INITIAL_CHECKPOINT);
@@ -193,6 +199,9 @@ public class IcebergMetadataUploaderService {
                     table.getTableId(),
                     initResponse.getStatusCode(),
                     initResponse.getCause());
+                metrics.incrementTableMetadataProcessingFailureCounter(
+                    MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR,
+                    "Failed to initialise Iceberg table");
                 return false;
               }
               return true;
@@ -328,6 +337,9 @@ public class IcebergMetadataUploaderService {
                     metadataJson.getFilename(),
                     urlResponse.getStatusCode(),
                     urlResponse.getCause());
+                metrics.incrementTableMetadataProcessingFailureCounter(
+                    MetricsConstants.MetadataUploadFailureReasons.PRESIGNED_URL_UPLOAD_FAILURE,
+                    "Failed to obtain presigned URL for Iceberg metadata.json");
                 return CompletableFuture.completedFuture(false);
               }
               String presigned = urlResponse.getUploadUrls().get(0);
@@ -383,6 +395,9 @@ public class IcebergMetadataUploaderService {
                     table.getTableId(),
                     upsert.getStatusCode(),
                     upsert.getCause());
+                metrics.incrementTableMetadataProcessingFailureCounter(
+                    MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR,
+                    "Failed to upsert checkpoint for Iceberg table");
                 return false;
               }
               return true;
@@ -402,6 +417,11 @@ public class IcebergMetadataUploaderService {
    *   <li>{@code 00001-a.metadata.json}, {@code 00010-b.metadata.json} →
    *       {@code 00010-b.metadata.json}</li>
    * </ul>
+   *
+   * <p><b>Caveat:</b> the highest-versioned file is not guaranteed to be the catalog's committed
+   * pointer — a failed or concurrent write can leave an orphan {@code metadata.json} with a higher
+   * version. This is a best-effort last resort; the {@code metadataLocationHint} and {@code
+   * version-hint.text} paths are authoritative and preferred precisely for that reason.
    */
   static Optional<File> pickLatestMetadataJson(List<File> files) {
     Comparator<File> byVersionThenName =

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergTableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergTableFormatDetector.java
@@ -1,0 +1,26 @@
+package ai.onehouse.metadata_extractor;
+
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FOLDER_NAME;
+
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.models.File;
+import java.util.List;
+
+/**
+ * A directory is an Iceberg table root if it contains a {@code metadata/} folder. The folder
+ * itself holds the {@code *.metadata.json} pointer files plus manifest list / manifest avros;
+ * presence alone is sufficient to identify the table root since Iceberg always emits {@code
+ * metadata/} on the first commit.
+ */
+public class IcebergTableFormatDetector implements TableFormatDetector {
+  @Override
+  public TableFormat format() {
+    return TableFormat.ICEBERG;
+  }
+
+  @Override
+  public boolean matches(List<File> listedFiles) {
+    return listedFiles.stream()
+        .anyMatch(file -> file.isDirectory() && ICEBERG_METADATA_FOLDER_NAME.equals(file.getFilename()));
+  }
+}

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergTableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergTableFormatDetector.java
@@ -1,26 +1,67 @@
 package ai.onehouse.metadata_extractor;
 
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FILE_SUFFIX;
 import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FOLDER_NAME;
 
+import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
 import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.AsyncStorageClient;
+import ai.onehouse.storage.StorageUtils;
 import ai.onehouse.storage.models.File;
+import com.google.inject.Inject;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
 
 /**
- * A directory is an Iceberg table root if it contains a {@code metadata/} folder. The folder
- * itself holds the {@code *.metadata.json} pointer files plus manifest list / manifest avros;
- * presence alone is sufficient to identify the table root since Iceberg always emits {@code
- * metadata/} on the first commit.
+ * A directory is an Iceberg table root if it contains a {@code metadata/} sub-directory <b>and</b>
+ * that sub-directory contains at least one {@code *.metadata.json} pointer file. The pointer-file
+ * check is what separates a real Iceberg table from any arbitrary folder that happens to have a
+ * sub-directory named {@code metadata} (a Spark checkpoint dir, a documentation folder, custom
+ * user layouts, etc.) — that name alone is too generic to be a reliable marker.
+ *
+ * <p>The validating LIST costs one extra storage call per candidate directory during discovery
+ * (not per upload cycle). Discovery already short-circuits recursion on a match, so the extra
+ * LIST runs at most once per real table and once per false-positive candidate during a discovery
+ * pass.
  */
 public class IcebergTableFormatDetector implements TableFormatDetector {
+  private final AsyncStorageClient asyncStorageClient;
+  private final StorageUtils storageUtils;
+
+  @Inject
+  public IcebergTableFormatDetector(
+      @Nonnull @TableDiscoveryObjectStorageAsyncClient AsyncStorageClient asyncStorageClient,
+      @Nonnull StorageUtils storageUtils) {
+    this.asyncStorageClient = asyncStorageClient;
+    this.storageUtils = storageUtils;
+  }
+
   @Override
   public TableFormat format() {
     return TableFormat.ICEBERG;
   }
 
   @Override
-  public boolean matches(List<File> listedFiles) {
-    return listedFiles.stream()
-        .anyMatch(file -> file.isDirectory() && ICEBERG_METADATA_FOLDER_NAME.equals(file.getFilename()));
+  public CompletableFuture<Boolean> matches(String path, List<File> listedFiles) {
+    boolean hasMetadataDir =
+        listedFiles.stream()
+            .anyMatch(
+                file ->
+                    file.isDirectory()
+                        && ICEBERG_METADATA_FOLDER_NAME.equals(file.getFilename()));
+    if (!hasMetadataDir) {
+      return CompletableFuture.completedFuture(false);
+    }
+    String metadataDirUri = storageUtils.constructFileUri(path, ICEBERG_METADATA_FOLDER_NAME);
+    return asyncStorageClient
+        .listAllFilesInDir(metadataDirUri)
+        .thenApply(
+            metadataFiles ->
+                metadataFiles.stream()
+                    .anyMatch(
+                        f ->
+                            !f.isDirectory()
+                                && f.getFilename().endsWith(ICEBERG_METADATA_FILE_SUFFIX)));
   }
 }

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergTableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergTableFormatDetector.java
@@ -44,12 +44,26 @@ public class IcebergTableFormatDetector implements TableFormatDetector {
 
   @Override
   public CompletableFuture<Boolean> matches(String path, List<File> listedFiles) {
+    // S3 ListObjectsV2 surfaces "directories" as CommonPrefixes, which the storage client
+    // maps to File objects whose filename retains the trailing slash (e.g. "metadata/"),
+    // since that is exactly the Prefix string S3 returns. Strip a trailing slash before
+    // comparing so the check works regardless of whether the client preserves it.
     boolean hasMetadataDir =
         listedFiles.stream()
             .anyMatch(
-                file ->
-                    file.isDirectory()
-                        && ICEBERG_METADATA_FOLDER_NAME.equals(file.getFilename()));
+                file -> {
+                  if (!file.isDirectory()) {
+                    return false;
+                  }
+                  String name = file.getFilename();
+                  if (name == null) {
+                    return false;
+                  }
+                  if (name.endsWith("/")) {
+                    name = name.substring(0, name.length() - 1);
+                  }
+                  return ICEBERG_METADATA_FOLDER_NAME.equals(name);
+                });
     if (!hasMetadataDir) {
       return CompletableFuture.completedFuture(false);
     }

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJob.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJob.java
@@ -1,5 +1,6 @@
 package ai.onehouse.metadata_extractor;
 
+import ai.onehouse.api.models.request.TableFormat;
 import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.storage.AsyncStorageClient;
@@ -18,13 +19,17 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,6 +39,7 @@ import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataE
 public class TableDiscoveryAndUploadJob {
   private final TableDiscoveryService tableDiscoveryService;
   private final TableMetadataUploaderService tableMetadataUploaderService;
+  private final IcebergMetadataUploaderService icebergMetadataUploaderService;
   private final ScheduledExecutorService scheduler;
   private final Object lock = new Object();
   private final LakeViewExtractorMetrics hudiMetadataExtractorMetrics;
@@ -47,14 +53,39 @@ public class TableDiscoveryAndUploadJob {
   public TableDiscoveryAndUploadJob(
       @Nonnull TableDiscoveryService tableDiscoveryService,
       @Nonnull TableMetadataUploaderService tableMetadataUploaderService,
+      @Nonnull IcebergMetadataUploaderService icebergMetadataUploaderService,
       @Nonnull LakeViewExtractorMetrics hudiMetadataExtractorMetrics,
       @Nonnull @TableDiscoveryObjectStorageAsyncClient AsyncStorageClient asyncStorageClient) {
     this.scheduler = getScheduler();
     this.tableDiscoveryService = tableDiscoveryService;
     this.tableMetadataUploaderService = tableMetadataUploaderService;
+    this.icebergMetadataUploaderService = icebergMetadataUploaderService;
     this.hudiMetadataExtractorMetrics = hudiMetadataExtractorMetrics;
     this.firstCronRunStartTime = Instant.now();
     this.asyncStorageClient = asyncStorageClient;
+  }
+
+  /**
+   * Routes discovered tables to the appropriate per-format uploader and reduces to a single
+   * success boolean (all-or-nothing). Hudi and Iceberg tables are uploaded concurrently.
+   */
+  private CompletableFuture<Boolean> dispatchUpload(Set<Table> tables) {
+    Map<TableFormat, Set<Table>> byFormat =
+        tables.stream()
+            .collect(
+                Collectors.groupingBy(
+                    t -> t.getTableFormat() == null ? TableFormat.HUDI : t.getTableFormat(),
+                    Collectors.toSet()));
+    CompletableFuture<Boolean> hudiFuture =
+        tableMetadataUploaderService.uploadInstantsInTables(
+            byFormat.getOrDefault(TableFormat.HUDI, Collections.emptySet()));
+    CompletableFuture<Boolean> icebergFuture =
+        icebergMetadataUploaderService.uploadInstantsInTables(
+            byFormat.getOrDefault(TableFormat.ICEBERG, Collections.emptySet()));
+    // Treat a null result the same as success — the legacy contract on the Hudi uploader was
+    // "throw to fail," and downstream callers only inspect exceptions, not the boolean.
+    return hudiFuture.thenCombine(
+        icebergFuture, (a, b) -> !Boolean.FALSE.equals(a) && !Boolean.FALSE.equals(b));
   }
 
   /*
@@ -96,7 +127,7 @@ public class TableDiscoveryAndUploadJob {
     Boolean isSucceeded =
         tableDiscoveryService
             .discoverTables()
-            .thenCompose(tableMetadataUploaderService::uploadInstantsInTables)
+            .thenCompose(this::dispatchUpload)
             .join();
     if (Boolean.TRUE.equals(isSucceeded)) {
       log.info("Run Completed");
@@ -178,8 +209,7 @@ public class TableDiscoveryAndUploadJob {
         log.debug("Uploading table metadata for discovered tables");
         hudiMetadataExtractorMetrics.resetTableProcessedGauge();
         AtomicBoolean hasError = new AtomicBoolean(false);
-        tableMetadataUploaderService
-            .uploadInstantsInTables(tables)
+        dispatchUpload(tables)
             .exceptionally(
                 ex -> {
                   log.error("Error uploading instants in tables: ", ex);

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -3,25 +3,26 @@ package ai.onehouse.metadata_extractor;
 import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataExtractorFailureReason;
 import static java.util.Collections.emptySet;
 
-import com.google.inject.Inject;
+import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
 import ai.onehouse.api.models.request.TableFormat;
-import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.config.ConfigProvider;
 import ai.onehouse.config.models.configv1.Database;
 import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.config.models.configv1.ParserConfig;
 import ai.onehouse.config.models.configv1.TableHint;
+import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.metadata_extractor.models.Table;
 import ai.onehouse.metrics.LakeViewExtractorMetrics;
 import ai.onehouse.storage.AsyncStorageClient;
 import ai.onehouse.storage.StorageUtils;
 import ai.onehouse.storage.models.File;
-import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,9 +34,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 /*
- * Discovers tables by Parsing all folders (including nested folders) in provided base paths.
- * Each directory is run through the registered {@link TableFormatDetector}s; the first detector
- * that matches determines the table's format. Excluded paths are skipped.
+ * Discovers tables by walking all folders (including nested folders) in provided base paths.
+ * Each {@link Database} in the parser YAML declares its {@code tableFormat}; this service picks
+ * the single {@link TableFormatDetector} matching that format and applies it to every directory
+ * under the database's base paths. Excluded paths are skipped.
  */
 @Slf4j
 public class TableDiscoveryService {
@@ -45,7 +47,7 @@ public class TableDiscoveryService {
   private final ExecutorService executorService;
   private final ConfigProvider configProvider;
   private final LakeViewExtractorMetrics lakeviewExtractorMetrics;
-  private final List<TableFormatDetector> tableFormatDetectors;
+  private final Map<TableFormat, TableFormatDetector> detectorsByFormat;
 
   @Inject
   public TableDiscoveryService(
@@ -61,10 +63,10 @@ public class TableDiscoveryService {
     this.executorService = executorService;
     this.configProvider = configProvider;
     this.lakeviewExtractorMetrics = lakeviewExtractorMetrics;
-    // Hudi listed first so existing tables short-circuit on the cheaper check; new formats append.
-    this.tableFormatDetectors =
-        Collections.unmodifiableList(
-            Arrays.asList(hudiTableFormatDetector, icebergTableFormatDetector));
+    this.detectorsByFormat =
+        ImmutableMap.of(
+            TableFormat.HUDI, hudiTableFormatDetector,
+            TableFormat.ICEBERG, icebergTableFormatDetector);
   }
 
   public CompletableFuture<Set<Table>> discoverTables() {
@@ -75,20 +77,29 @@ public class TableDiscoveryService {
     log.info("Starting table discover service, excluding {}", excludedPathPatterns);
     List<Pair<String, CompletableFuture<Set<Table>>>> pathToDiscoveredTablesFuturePairList =
         new ArrayList<>();
-    // Merge per-database tableHints into a single tableId -> hint map. Hints are
-    // optional metadata supplied by the control plane (e.g. Iceberg metadata_location)
-    // and are looked up after discovery, once the tableId is known.
-    java.util.Map<String, TableHint> tableHintsByTableId = new java.util.HashMap<>();
+    // Merge per-database tableHints into a single tableId -> hint map. Hints are optional metadata
+    // supplied by the control plane (e.g. Iceberg metadata_location) and are looked up after
+    // discovery, once the tableId is known.
+    Map<String, TableHint> tableHintsByTableId = new HashMap<>();
     for (ParserConfig parserConfig : metadataExtractorConfig.getParserConfig()) {
       for (Database database : parserConfig.getDatabases()) {
-        if (database.getTableHints() != null) {
-          tableHintsByTableId.putAll(database.getTableHints());
+        if (database.getTableHints() == null) {
+          continue;
+        }
+        for (Map.Entry<String, TableHint> entry : database.getTableHints().entrySet()) {
+          TableHint previous = tableHintsByTableId.put(entry.getKey(), entry.getValue());
+          if (previous != null) {
+            log.warn(
+                "Duplicate tableHint for tableId {} across databases; later entry wins.",
+                entry.getKey());
+          }
         }
       }
     }
 
     for (ParserConfig parserConfig : metadataExtractorConfig.getParserConfig()) {
       for (Database database : parserConfig.getDatabases()) {
+        TableFormatDetector detector = detectorFor(database);
         for (String basePathConfig : database.getBasePaths()) {
           String basePath = extractBasePath(basePathConfig);
 
@@ -100,7 +111,11 @@ public class TableDiscoveryService {
               Pair.of(
                   basePathConfig,
                   discoverTablesInPath(
-                      basePath, parserConfig.getLake(), database.getName(), excludedPathPatterns)));
+                      basePath,
+                      parserConfig.getLake(),
+                      database.getName(),
+                      excludedPathPatterns,
+                      detector)));
         }
       }
     }
@@ -143,6 +158,16 @@ public class TableDiscoveryService {
             });
   }
 
+  private TableFormatDetector detectorFor(Database database) {
+    TableFormat declared = database.getTableFormat() == null ? TableFormat.HUDI : database.getTableFormat();
+    TableFormatDetector detector = detectorsByFormat.get(declared);
+    if (detector == null) {
+      // Programmer error: a new TableFormat enum value was added without a matching detector.
+      throw new IllegalStateException("No detector registered for tableFormat=" + declared);
+    }
+    return detector;
+  }
+
   private String extractBasePath(String basePathConfig) {
     String[] basePathConfigParts = basePathConfig.split(TABLE_ID_SEPARATOR);
     return basePathConfigParts[0];
@@ -154,71 +179,74 @@ public class TableDiscoveryService {
   }
 
   private CompletableFuture<Set<Table>> discoverTablesInPath(
-      String path, String lakeName, String databaseName, List<String> excludedPathPatterns) {
+      String path,
+      String lakeName,
+      String databaseName,
+      List<String> excludedPathPatterns,
+      TableFormatDetector detector) {
     try {
       log.info(String.format("Discovering tables in %s", path));
       return asyncStorageClient
           .listAllFilesInDir(path)
           .thenComposeAsync(
-              listedFiles -> {
-                Set<Table> tablePaths = ConcurrentHashMap.newKeySet();
-                List<CompletableFuture<Void>> recursiveFutures = new ArrayList<>();
+              listedFiles ->
+                  detector
+                      .matches(path, listedFiles)
+                      .thenComposeAsync(
+                          matched -> {
+                            Set<Table> tablePaths = ConcurrentHashMap.newKeySet();
+                            if (Boolean.TRUE.equals(matched)) {
+                              Table table =
+                                  Table.builder()
+                                      .absoluteTableUri(path)
+                                      .databaseName(databaseName)
+                                      .lakeName(lakeName)
+                                      .tableFormat(detector.format())
+                                      .build();
+                              if (!isExcluded(table.getAbsoluteTableUri(), excludedPathPatterns)) {
+                                tablePaths.add(table);
+                              }
+                              return CompletableFuture.completedFuture(tablePaths);
+                            }
 
-                Optional<TableFormat> detected = detectTableFormat(listedFiles);
-                if (detected.isPresent()) {
-                  Table table =
-                      Table.builder()
-                          .absoluteTableUri(path)
-                          .databaseName(databaseName)
-                          .lakeName(lakeName)
-                          .tableFormat(detected.get())
-                          .build();
-                  if (!isExcluded(table.getAbsoluteTableUri(), excludedPathPatterns)) {
-                    tablePaths.add(table);
-                  }
-                  return CompletableFuture.completedFuture(tablePaths);
-                }
-
-                List<File> directories =
-                    listedFiles.stream().filter(File::isDirectory).collect(Collectors.toList());
-
-                for (File file : directories) {
-                  String filePath = storageUtils.constructFileUri(path, file.getFilename());
-                  if (!isExcluded(filePath, excludedPathPatterns)) {
-                    CompletableFuture<Void> recursiveFuture =
-                        discoverTablesInPath(filePath, lakeName, databaseName, excludedPathPatterns)
-                            .thenAccept(tablePaths::addAll);
-                    recursiveFutures.add(recursiveFuture);
-                  }
-                }
-
-                return CompletableFuture.allOf(recursiveFutures.toArray(new CompletableFuture[0]))
-                    .thenApplyAsync(ignored -> tablePaths, executorService);
-              },
+                            List<File> directories =
+                                listedFiles.stream()
+                                    .filter(File::isDirectory)
+                                    .collect(Collectors.toList());
+                            List<CompletableFuture<Void>> recursiveFutures = new ArrayList<>();
+                            for (File file : directories) {
+                              String filePath =
+                                  storageUtils.constructFileUri(path, file.getFilename());
+                              if (!isExcluded(filePath, excludedPathPatterns)) {
+                                CompletableFuture<Void> recursiveFuture =
+                                    discoverTablesInPath(
+                                            filePath,
+                                            lakeName,
+                                            databaseName,
+                                            excludedPathPatterns,
+                                            detector)
+                                        .thenAccept(tablePaths::addAll);
+                                recursiveFutures.add(recursiveFuture);
+                              }
+                            }
+                            return CompletableFuture.allOf(
+                                    recursiveFutures.toArray(new CompletableFuture[0]))
+                                .thenApplyAsync(ignored -> tablePaths, executorService);
+                          },
+                          executorService),
               executorService)
           .exceptionally(
               e -> {
                 log.error("Failed to discover tables in path: {}", path, e);
                 lakeviewExtractorMetrics.incrementTableDiscoveryFailureCounter(
-                  getMetadataExtractorFailureReason(
-                    e,
-                    MetricsConstants.MetadataUploadFailureReasons.UNKNOWN)
-                );
+                    getMetadataExtractorFailureReason(
+                        e, MetricsConstants.MetadataUploadFailureReasons.UNKNOWN));
                 return emptySet();
               });
     } catch (Exception e) {
       log.error("Failed to discover tables in path: {}", path, e);
       return CompletableFuture.completedFuture(emptySet());
     }
-  }
-
-  private Optional<TableFormat> detectTableFormat(List<File> listedFiles) {
-    for (TableFormatDetector detector : tableFormatDetectors) {
-      if (detector.matches(listedFiles)) {
-        return Optional.of(detector.format());
-      }
-    }
-    return Optional.empty();
   }
 
   private boolean isExcluded(String filePath, List<String> excludedPathPatterns) {

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -10,6 +10,7 @@ import ai.onehouse.config.ConfigProvider;
 import ai.onehouse.config.models.configv1.Database;
 import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.config.models.configv1.ParserConfig;
+import ai.onehouse.config.models.configv1.TableHint;
 import ai.onehouse.metadata_extractor.models.Table;
 import ai.onehouse.metrics.LakeViewExtractorMetrics;
 import ai.onehouse.storage.AsyncStorageClient;
@@ -74,6 +75,17 @@ public class TableDiscoveryService {
     log.info("Starting table discover service, excluding {}", excludedPathPatterns);
     List<Pair<String, CompletableFuture<Set<Table>>>> pathToDiscoveredTablesFuturePairList =
         new ArrayList<>();
+    // Merge per-database tableHints into a single tableId -> hint map. Hints are
+    // optional metadata supplied by the control plane (e.g. Iceberg metadata_location)
+    // and are looked up after discovery, once the tableId is known.
+    java.util.Map<String, TableHint> tableHintsByTableId = new java.util.HashMap<>();
+    for (ParserConfig parserConfig : metadataExtractorConfig.getParserConfig()) {
+      for (Database database : parserConfig.getDatabases()) {
+        if (database.getTableHints() != null) {
+          tableHintsByTableId.putAll(database.getTableHints());
+        }
+      }
+    }
 
     for (ParserConfig parserConfig : metadataExtractorConfig.getParserConfig()) {
       for (Database database : parserConfig.getDatabases()) {
@@ -116,7 +128,12 @@ public class TableDiscoveryService {
                     continue;
                   }
                   Table table = discoveredTables.iterator().next();
-                  table = table.toBuilder().tableId(tableId).build();
+                  Table.TableBuilder builder = table.toBuilder().tableId(tableId);
+                  TableHint hint = tableHintsByTableId.get(tableId);
+                  if (hint != null && StringUtils.isNotBlank(hint.getMetadataLocationHint())) {
+                    builder.metadataLocationHint(hint.getMetadataLocationHint());
+                  }
+                  table = builder.build();
                   discoveredTables = Collections.singleton(table);
                 }
 

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -1,10 +1,10 @@
 package ai.onehouse.metadata_extractor;
 
-import static ai.onehouse.constants.MetadataExtractorConstants.HOODIE_FOLDER_NAME;
 import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataExtractorFailureReason;
 import static java.util.Collections.emptySet;
 
 import com.google.inject.Inject;
+import ai.onehouse.api.models.request.TableFormat;
 import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.config.ConfigProvider;
 import ai.onehouse.config.models.configv1.Database;
@@ -17,8 +17,10 @@ import ai.onehouse.storage.StorageUtils;
 import ai.onehouse.storage.models.File;
 import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,8 +32,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 /*
- * Discovers hudi tables by Parsing all folders (including nested folders) in provided base paths
- * excluded paths will be skipped.
+ * Discovers tables by Parsing all folders (including nested folders) in provided base paths.
+ * Each directory is run through the registered {@link TableFormatDetector}s; the first detector
+ * that matches determines the table's format. Excluded paths are skipped.
  */
 @Slf4j
 public class TableDiscoveryService {
@@ -41,6 +44,7 @@ public class TableDiscoveryService {
   private final ExecutorService executorService;
   private final ConfigProvider configProvider;
   private final LakeViewExtractorMetrics lakeviewExtractorMetrics;
+  private final List<TableFormatDetector> tableFormatDetectors;
 
   @Inject
   public TableDiscoveryService(
@@ -48,12 +52,18 @@ public class TableDiscoveryService {
       @Nonnull StorageUtils storageUtils,
       @Nonnull ConfigProvider configProvider,
       @Nonnull ExecutorService executorService,
-      @Nonnull LakeViewExtractorMetrics lakeviewExtractorMetrics) {
+      @Nonnull LakeViewExtractorMetrics lakeviewExtractorMetrics,
+      @Nonnull HudiTableFormatDetector hudiTableFormatDetector,
+      @Nonnull IcebergTableFormatDetector icebergTableFormatDetector) {
     this.asyncStorageClient = asyncStorageClient;
     this.storageUtils = storageUtils;
     this.executorService = executorService;
     this.configProvider = configProvider;
     this.lakeviewExtractorMetrics = lakeviewExtractorMetrics;
+    // Hudi listed first so existing tables short-circuit on the cheaper check; new formats append.
+    this.tableFormatDetectors =
+        Collections.unmodifiableList(
+            Arrays.asList(hudiTableFormatDetector, icebergTableFormatDetector));
   }
 
   public CompletableFuture<Set<Table>> discoverTables() {
@@ -137,12 +147,14 @@ public class TableDiscoveryService {
                 Set<Table> tablePaths = ConcurrentHashMap.newKeySet();
                 List<CompletableFuture<Void>> recursiveFutures = new ArrayList<>();
 
-                if (isHudiTableFolder(listedFiles)) {
+                Optional<TableFormat> detected = detectTableFormat(listedFiles);
+                if (detected.isPresent()) {
                   Table table =
                       Table.builder()
                           .absoluteTableUri(path)
                           .databaseName(databaseName)
                           .lakeName(lakeName)
+                          .tableFormat(detected.get())
                           .build();
                   if (!isExcluded(table.getAbsoluteTableUri(), excludedPathPatterns)) {
                     tablePaths.add(table);
@@ -183,12 +195,13 @@ public class TableDiscoveryService {
     }
   }
 
-  /*
-   *  checks the contents of a folder to see if it is a hudi table or not
-   *  a folder is a hudi table if it contains .hoodie folder within it
-   */
-  private static boolean isHudiTableFolder(List<File> listedFiles) {
-    return listedFiles.stream().anyMatch(file -> file.getFilename().startsWith(HOODIE_FOLDER_NAME));
+  private Optional<TableFormat> detectTableFormat(List<File> listedFiles) {
+    for (TableFormatDetector detector : tableFormatDetectors) {
+      if (detector.matches(listedFiles)) {
+        return Optional.of(detector.format());
+      }
+    }
+    return Optional.empty();
   }
 
   private boolean isExcluded(String filePath, List<String> excludedPathPatterns) {

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -212,7 +213,9 @@ public class TableDiscoveryService {
                             }
 
                             List<File> directories =
-                                listedFiles.stream().filter(File::isDirectory).toList();
+                                listedFiles.stream()
+                                    .filter(File::isDirectory)
+                                    .collect(Collectors.toList());
                             List<CompletableFuture<Void>> recursiveFutures = new ArrayList<>();
                             for (File file : directories) {
                               String filePath =

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -144,6 +143,9 @@ public class TableDiscoveryService {
                   }
                   Table table = discoveredTables.iterator().next();
                   Table.TableBuilder builder = table.toBuilder().tableId(tableId);
+                  // metadataLocationHint is only applied here, on base paths pinned with an
+                  // explicit "#tableId". Auto-discovered tables (no tableId in the config) never
+                  // carry a hint and always fall back to listing metadata/ at upload time.
                   TableHint hint = tableHintsByTableId.get(tableId);
                   if (hint != null && StringUtils.isNotBlank(hint.getMetadataLocationHint())) {
                     builder.metadataLocationHint(hint.getMetadataLocationHint());
@@ -210,9 +212,7 @@ public class TableDiscoveryService {
                             }
 
                             List<File> directories =
-                                listedFiles.stream()
-                                    .filter(File::isDirectory)
-                                    .collect(Collectors.toList());
+                                listedFiles.stream().filter(File::isDirectory).toList();
                             List<CompletableFuture<Void>> recursiveFutures = new ArrayList<>();
                             for (File file : directories) {
                               String filePath =

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableFormatDetector.java
@@ -3,18 +3,29 @@ package ai.onehouse.metadata_extractor;
 import ai.onehouse.api.models.request.TableFormat;
 import ai.onehouse.storage.models.File;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Identifies whether a directory listing represents the root of a table of a particular format.
  *
- * <p>One implementation per supported format (Hudi, Iceberg, ...). {@link TableDiscoveryService}
- * iterates registered detectors and stops at the first match, so detectors should be cheap and
- * unambiguous.
+ * <p>One implementation per supported format (Hudi, Iceberg, ...). Each {@code Database} in the
+ * parser YAML declares its {@code tableFormat}, and {@link TableDiscoveryService} picks the
+ * single matching detector for that database — detectors are not raced against each other, so
+ * there is no ordering trap.
+ *
+ * <p>{@link #matches} returns a {@link CompletableFuture} because some detectors need a follow-up
+ * directory listing to confirm a match (e.g. Iceberg's "must have a {@code *.metadata.json}
+ * inside {@code metadata/}" rule). Stateless detectors should return {@link
+ * CompletableFuture#completedFuture}.
  */
 public interface TableFormatDetector {
   /** Format this detector identifies. */
   TableFormat format();
 
-  /** Returns true if the listed files at a directory indicate a table root of {@link #format()}. */
-  boolean matches(List<File> listedFiles);
+  /**
+   * Returns true if the directory at {@code path} (with its top-level listing already in {@code
+   * listedFiles}) is a table root of {@link #format()}. Implementations may issue additional
+   * storage I/O to validate.
+   */
+  CompletableFuture<Boolean> matches(String path, List<File> listedFiles);
 }

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableFormatDetector.java
@@ -1,0 +1,20 @@
+package ai.onehouse.metadata_extractor;
+
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.models.File;
+import java.util.List;
+
+/**
+ * Identifies whether a directory listing represents the root of a table of a particular format.
+ *
+ * <p>One implementation per supported format (Hudi, Iceberg, ...). {@link TableDiscoveryService}
+ * iterates registered detectors and stops at the first match, so detectors should be cheap and
+ * unambiguous.
+ */
+public interface TableFormatDetector {
+  /** Format this detector identifies. */
+  TableFormat format();
+
+  /** Returns true if the listed files at a directory indicate a table root of {@link #format()}. */
+  boolean matches(List<File> listedFiles);
+}

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/models/Table.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/models/Table.java
@@ -3,6 +3,7 @@ package ai.onehouse.metadata_extractor.models;
 import static ai.onehouse.constants.MetadataExtractorConstants.HOODIE_TABLE_VERSION_DEFAULT;
 import static ai.onehouse.constants.MetadataExtractorConstants.TIMELINE_LAYOUT_VERSION_DEFAULT;
 
+import ai.onehouse.api.models.request.TableFormat;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -20,4 +21,6 @@ public class Table {
   private String tableId;
   @Builder.Default private final int tableVersion = HOODIE_TABLE_VERSION_DEFAULT;
   @Builder.Default private final int timelineLayoutVersion = TIMELINE_LAYOUT_VERSION_DEFAULT;
+  // tableVersion / timelineLayoutVersion above are Hudi-specific and ignored for non-Hudi formats.
+  @Builder.Default private final TableFormat tableFormat = TableFormat.HUDI;
 }

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/models/Table.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/models/Table.java
@@ -23,4 +23,11 @@ public class Table {
   @Builder.Default private final int timelineLayoutVersion = TIMELINE_LAYOUT_VERSION_DEFAULT;
   // tableVersion / timelineLayoutVersion above are Hudi-specific and ignored for non-Hudi formats.
   @Builder.Default private final TableFormat tableFormat = TableFormat.HUDI;
+  /**
+   * Optional URI of the current Iceberg {@code metadata.json}, supplied by the control plane via
+   * the parser YAML's table hints. Null when no hint was provided. {@link
+   * ai.onehouse.metadata_extractor.IcebergMetadataUploaderService} uses this to skip the per-cycle
+   * {@code metadata/} folder LIST when the hint matches the last uploaded file.
+   */
+  private final String metadataLocationHint;
 }

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
@@ -40,6 +40,7 @@ class TableDiscoveryAndUploadJobTest {
   @Mock private TableDiscoveryService mockTableDiscoveryService;
 
   @Mock private TableMetadataUploaderService mockTableMetadataUploaderService;
+  @Mock private IcebergMetadataUploaderService mockIcebergMetadataUploaderService;
 
   @Mock private ScheduledExecutorService mockScheduler;
 
@@ -56,6 +57,12 @@ class TableDiscoveryAndUploadJobTest {
 
   @BeforeEach
   void setUp(TestInfo info) {
+    // Existing tests exercise the Hudi path; dispatch routes any Iceberg-format tables (none in
+    // these tests) to the Iceberg uploader. Default the mock to a successful no-op so the dispatch
+    // combine doesn't NPE on the (empty Iceberg set) branch.
+    lenient()
+        .when(mockIcebergMetadataUploaderService.uploadInstantsInTables(anySet()))
+        .thenReturn(CompletableFuture.completedFuture(true));
     Instant fixedInstant =
         info.getDisplayName().startsWith("2023") ? Instant.parse(info.getDisplayName()) : Instant.now();
     try (MockedStatic<Instant> mockedInstant =
@@ -65,6 +72,7 @@ class TableDiscoveryAndUploadJobTest {
           new TableDiscoveryAndUploadJob(
               mockTableDiscoveryService,
               mockTableMetadataUploaderService,
+              mockIcebergMetadataUploaderService,
               mockHudiMetadataExtractorMetrics,
               asyncStorageClient) {
             @Override

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
@@ -4,6 +4,7 @@ import static ai.onehouse.constants.MetadataExtractorConstants.PROCESS_TABLE_MET
 import static ai.onehouse.constants.MetadataExtractorConstants.TABLE_DISCOVERY_INTERVAL_MINUTES;
 import static org.mockito.Mockito.*;
 
+import ai.onehouse.api.models.request.TableFormat;
 import ai.onehouse.config.Config;
 import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.constants.MetricsConstants;
@@ -13,6 +14,7 @@ import ai.onehouse.metrics.LakeViewExtractorMetrics;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -179,6 +181,38 @@ class TableDiscoveryAndUploadJobTest {
     verify(mockTableDiscoveryService, times(1)).discoverTables();
     verify(mockTableMetadataUploaderService, times(1))
         .uploadInstantsInTables(Collections.singleton(discoveredTable));
+  }
+
+  @Test
+  void testDispatchRoutesTablesByFormat() {
+    Table hudiTable =
+        Table.builder()
+            .absoluteTableUri("s3://bucket/hudi_db/t")
+            .lakeName("lake")
+            .databaseName("hudi_db")
+            .tableFormat(TableFormat.HUDI)
+            .build();
+    Table icebergTable =
+        Table.builder()
+            .absoluteTableUri("s3://bucket/iceberg_db/t")
+            .lakeName("lake")
+            .databaseName("iceberg_db")
+            .tableFormat(TableFormat.ICEBERG)
+            .build();
+    when(mockTableDiscoveryService.discoverTables())
+        .thenReturn(CompletableFuture.completedFuture(Set.of(hudiTable, icebergTable)));
+    when(mockTableMetadataUploaderService.uploadInstantsInTables(anySet()))
+        .thenReturn(CompletableFuture.completedFuture(true));
+    when(mockIcebergMetadataUploaderService.uploadInstantsInTables(anySet()))
+        .thenReturn(CompletableFuture.completedFuture(true));
+
+    job.runOnce();
+
+    // Each uploader receives exactly its own format's partition — never the other's.
+    verify(mockTableMetadataUploaderService)
+        .uploadInstantsInTables(Collections.singleton(hudiTable));
+    verify(mockIcebergMetadataUploaderService)
+        .uploadInstantsInTables(Collections.singleton(icebergTable));
   }
 
   @ParameterizedTest(name = "{0}")

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
@@ -11,10 +11,10 @@ import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.exceptions.RateLimitException;
 import ai.onehouse.metadata_extractor.models.Table;
 import ai.onehouse.metrics.LakeViewExtractorMetrics;
+import com.google.common.collect.ImmutableSet;
 
 import java.time.Instant;
 import java.util.Collections;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -200,7 +200,8 @@ class TableDiscoveryAndUploadJobTest {
             .tableFormat(TableFormat.ICEBERG)
             .build();
     when(mockTableDiscoveryService.discoverTables())
-        .thenReturn(CompletableFuture.completedFuture(Set.of(hudiTable, icebergTable)));
+        .thenReturn(
+            CompletableFuture.completedFuture(ImmutableSet.of(hudiTable, icebergTable)));
     when(mockTableMetadataUploaderService.uploadInstantsInTables(anySet()))
         .thenReturn(CompletableFuture.completedFuture(true));
     when(mockIcebergMetadataUploaderService.uploadInstantsInTables(anySet()))

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
@@ -164,7 +164,9 @@ class TableDiscoveryServiceTest {
             new StorageUtils(),
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
-            hudiMetadataExtractorMetrics);
+            hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector());
 
     Set<Table> tableSet = tableDiscoveryService.discoverTables().get();
     List<Table> expectedResponseSet =
@@ -256,7 +258,9 @@ class TableDiscoveryServiceTest {
             new StorageUtils(),
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
-            hudiMetadataExtractorMetrics);
+            hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector());
 
     Set<Table> discoveredTables = tableDiscoveryService.discoverTables().join();
     assertEquals(emptySet(), discoveredTables);
@@ -294,7 +298,9 @@ class TableDiscoveryServiceTest {
             new StorageUtils(),
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
-            hudiMetadataExtractorMetrics);
+            hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector());
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
   }
 
@@ -326,7 +332,9 @@ class TableDiscoveryServiceTest {
             new StorageUtils(),
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
-            hudiMetadataExtractorMetrics);
+            hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector());
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
   }
 
@@ -357,7 +365,9 @@ class TableDiscoveryServiceTest {
                     new StorageUtils(),
                     new ConfigProvider(config),
                     ForkJoinPool.commonPool(),
-                    hudiMetadataExtractorMetrics);
+                    hudiMetadataExtractorMetrics,
+                    new HudiTableFormatDetector(),
+                    new IcebergTableFormatDetector());
 
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
 

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
@@ -166,7 +166,7 @@ class TableDiscoveryServiceTest {
             ForkJoinPool.commonPool(),
             hudiMetadataExtractorMetrics,
             new HudiTableFormatDetector(),
-            new IcebergTableFormatDetector());
+            new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils()));
 
     Set<Table> tableSet = tableDiscoveryService.discoverTables().get();
     List<Table> expectedResponseSet =
@@ -260,7 +260,7 @@ class TableDiscoveryServiceTest {
             ForkJoinPool.commonPool(),
             hudiMetadataExtractorMetrics,
             new HudiTableFormatDetector(),
-            new IcebergTableFormatDetector());
+            new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils()));
 
     Set<Table> discoveredTables = tableDiscoveryService.discoverTables().join();
     assertEquals(emptySet(), discoveredTables);
@@ -300,7 +300,7 @@ class TableDiscoveryServiceTest {
             ForkJoinPool.commonPool(),
             hudiMetadataExtractorMetrics,
             new HudiTableFormatDetector(),
-            new IcebergTableFormatDetector());
+            new IcebergTableFormatDetector(s3AsyncStorageClient, new StorageUtils()));
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
   }
 
@@ -334,7 +334,7 @@ class TableDiscoveryServiceTest {
             ForkJoinPool.commonPool(),
             hudiMetadataExtractorMetrics,
             new HudiTableFormatDetector(),
-            new IcebergTableFormatDetector());
+            new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils()));
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
   }
 
@@ -367,7 +367,7 @@ class TableDiscoveryServiceTest {
                     ForkJoinPool.commonPool(),
                     hudiMetadataExtractorMetrics,
                     new HudiTableFormatDetector(),
-                    new IcebergTableFormatDetector());
+                    new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils()));
 
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
 
@@ -375,6 +375,72 @@ class TableDiscoveryServiceTest {
     verify(hudiMetadataExtractorMetrics)
             .incrementTableDiscoveryFailureCounter(
                     MetricsConstants.MetadataUploadFailureReasons.RATE_LIMITING);
+  }
+
+  @Test
+  void testDiscoverIcebergTableByDeclaredFormat() {
+    // Database declared as ICEBERG. Two children: `orders/` is a real Iceberg table (metadata/
+    // with a *.metadata.json), `docs/` is a false-positive shape (metadata/ but no .metadata.json
+    // inside) and must be skipped.
+    String basePath = "s3://bucket/iceberg_warehouse/";
+    String ordersPath = basePath + "orders/";
+    String ordersMetadata = ordersPath + "metadata";
+    String docsPath = basePath + "docs/";
+    String docsMetadata = docsPath + "metadata";
+
+    when(asyncStorageClient.listAllFilesInDir(basePath))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(generateFileObj("orders/", true), generateFileObj("docs/", true))));
+    when(asyncStorageClient.listAllFilesInDir(ordersPath))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(
+                    generateFileObj("metadata", true), generateFileObj("data", true))));
+    when(asyncStorageClient.listAllFilesInDir(ordersMetadata))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(generateFileObj("v1.metadata.json", false))));
+    when(asyncStorageClient.listAllFilesInDir(docsPath))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(generateFileObj("metadata", true))));
+    when(asyncStorageClient.listAllFilesInDir(docsMetadata))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(generateFileObj("README.md", false))));
+
+    when(config.getMetadataExtractorConfig()).thenReturn(metadataExtractorConfig);
+    when(metadataExtractorConfig.getPathExclusionPatterns()).thenReturn(Optional.of(emptyList()));
+    when(metadataExtractorConfig.getParserConfig())
+        .thenReturn(
+            Collections.singletonList(
+                ParserConfig.builder()
+                    .lake(LAKE)
+                    .databases(
+                        Collections.singletonList(
+                            Database.builder()
+                                .name(DATABASE)
+                                .tableFormat(ai.onehouse.api.models.request.TableFormat.ICEBERG)
+                                .basePaths(Collections.singletonList(basePath))
+                                .build()))
+                    .build()));
+
+    tableDiscoveryService =
+        new TableDiscoveryService(
+            asyncStorageClient,
+            new StorageUtils(),
+            new ConfigProvider(config),
+            ForkJoinPool.commonPool(),
+            hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils()));
+
+    Set<Table> tables = tableDiscoveryService.discoverTables().join();
+    assertEquals(1, tables.size());
+    Table only = tables.iterator().next();
+    assertEquals(ordersPath, only.getAbsoluteTableUri());
+    assertEquals(ai.onehouse.api.models.request.TableFormat.ICEBERG, only.getTableFormat());
   }
 
   private File generateFileObj(String fileName, boolean isDirectory) {

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestHudiTableFormatDetector.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestHudiTableFormatDetector.java
@@ -1,0 +1,46 @@
+package ai.onehouse.metadata_extractor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.models.File;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class TestHudiTableFormatDetector {
+  private final HudiTableFormatDetector detector = new HudiTableFormatDetector();
+
+  @Test
+  void declaresHudiFormat() {
+    assertEquals(TableFormat.HUDI, detector.format());
+  }
+
+  @Test
+  void matchesWhenHoodieFolderPresent() {
+    assertTrue(
+        detector.matches(
+            Arrays.asList(
+                file(".hoodie", true),
+                file("part-0.parquet", false))));
+  }
+
+  @Test
+  void doesNotMatchWhenAbsent() {
+    assertFalse(detector.matches(Collections.singletonList(file("part-0.parquet", false))));
+  }
+
+  @Test
+  void doesNotMatchOnIcebergLayout() {
+    assertFalse(
+        detector.matches(
+            Arrays.asList(file("metadata", true), file("data", true))));
+  }
+
+  private static File file(String name, boolean dir) {
+    return File.builder().filename(name).isDirectory(dir).lastModifiedAt(Instant.EPOCH).build();
+  }
+}

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestHudiTableFormatDetector.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestHudiTableFormatDetector.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class TestHudiTableFormatDetector {
+  private static final String ANY_PATH = "s3://bucket/db/t/";
   private final HudiTableFormatDetector detector = new HudiTableFormatDetector();
 
   @Test
@@ -22,22 +23,27 @@ class TestHudiTableFormatDetector {
   @Test
   void matchesWhenHoodieFolderPresent() {
     assertTrue(
-        detector.matches(
-            Arrays.asList(
-                file(".hoodie", true),
-                file("part-0.parquet", false))));
+        detector
+            .matches(
+                ANY_PATH,
+                Arrays.asList(file(".hoodie", true), file("part-0.parquet", false)))
+            .join());
   }
 
   @Test
   void doesNotMatchWhenAbsent() {
-    assertFalse(detector.matches(Collections.singletonList(file("part-0.parquet", false))));
+    assertFalse(
+        detector
+            .matches(ANY_PATH, Collections.singletonList(file("part-0.parquet", false)))
+            .join());
   }
 
   @Test
   void doesNotMatchOnIcebergLayout() {
     assertFalse(
-        detector.matches(
-            Arrays.asList(file("metadata", true), file("data", true))));
+        detector
+            .matches(ANY_PATH, Arrays.asList(file("metadata", true), file("data", true)))
+            .join());
   }
 
   private static File file(String name, boolean dir) {

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
@@ -60,6 +60,23 @@ class TestIcebergMetadataUploaderService {
             .isPresent());
   }
 
+  @Test
+  void lastPathSegmentExtractsFilenameFromUri() {
+    assertEquals(
+        "00042-uuid.metadata.json",
+        IcebergMetadataUploaderService.lastPathSegment(
+            "s3://bucket/db/t/metadata/00042-uuid.metadata.json"));
+    assertEquals(
+        "v3.metadata.json",
+        IcebergMetadataUploaderService.lastPathSegment(
+            "s3a://bucket/db/t/metadata/v3.metadata.json"));
+  }
+
+  @Test
+  void lastPathSegmentReturnsInputWhenNoSlash() {
+    assertEquals("filename.json", IcebergMetadataUploaderService.lastPathSegment("filename.json"));
+  }
+
   private static File jsonFile(String name) {
     return File.builder().filename(name).isDirectory(false).lastModifiedAt(Instant.EPOCH).build();
   }

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
@@ -1,0 +1,66 @@
+package ai.onehouse.metadata_extractor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.onehouse.storage.models.File;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class TestIcebergMetadataUploaderService {
+
+  @Test
+  void picksLexicographicallyLatestHiveStyleMetadataJson() {
+    Optional<File> latest =
+        IcebergMetadataUploaderService.pickLatestMetadataJson(
+            Arrays.asList(
+                jsonFile("00000-abc.metadata.json"),
+                jsonFile("00020-xyz.metadata.json"),
+                jsonFile("00005-def.metadata.json")));
+    assertTrue(latest.isPresent());
+    assertEquals("00020-xyz.metadata.json", latest.get().getFilename());
+  }
+
+  @Test
+  void picksLatestHadoopCatalogMetadataJson() {
+    Optional<File> latest =
+        IcebergMetadataUploaderService.pickLatestMetadataJson(
+            Arrays.asList(
+                jsonFile("v1.metadata.json"),
+                jsonFile("v2.metadata.json"),
+                jsonFile("v10.metadata.json")));
+    assertTrue(latest.isPresent());
+    // Hadoop catalog convention is zero-padded in practice; bare integers sort poorly but we still
+    // pick *a* result deterministically. Document the limitation rather than hide it.
+    assertEquals("v2.metadata.json", latest.get().getFilename());
+  }
+
+  @Test
+  void ignoresDirectoriesAndUnrelatedFiles() {
+    Optional<File> latest =
+        IcebergMetadataUploaderService.pickLatestMetadataJson(
+            Arrays.asList(
+                File.builder().filename("snap-x.avro").isDirectory(false).lastModifiedAt(Instant.EPOCH).build(),
+                File.builder().filename("sub").isDirectory(true).lastModifiedAt(Instant.EPOCH).build(),
+                jsonFile("00001-a.metadata.json")));
+    assertTrue(latest.isPresent());
+    assertEquals("00001-a.metadata.json", latest.get().getFilename());
+  }
+
+  @Test
+  void returnsEmptyWhenNoMetadataJson() {
+    assertFalse(
+        IcebergMetadataUploaderService.pickLatestMetadataJson(
+                Collections.singletonList(
+                    File.builder().filename("snap.avro").isDirectory(false).lastModifiedAt(Instant.EPOCH).build()))
+            .isPresent());
+  }
+
+  private static File jsonFile(String name) {
+    return File.builder().filename(name).isDirectory(false).lastModifiedAt(Instant.EPOCH).build();
+  }
+}

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.onehouse.storage.models.File;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -14,7 +15,7 @@ import org.junit.jupiter.api.Test;
 class TestIcebergMetadataUploaderService {
 
   @Test
-  void picksLexicographicallyLatestHiveStyleMetadataJson() {
+  void picksLatestHiveGlueStyleMetadataJsonByNumericPrefix() {
     Optional<File> latest =
         IcebergMetadataUploaderService.pickLatestMetadataJson(
             Arrays.asList(
@@ -26,17 +27,19 @@ class TestIcebergMetadataUploaderService {
   }
 
   @Test
-  void picksLatestHadoopCatalogMetadataJson() {
+  void picksLatestHadoopCatalogMetadataJsonByVersionNumber() {
+    // v10 is numerically newer than v2 — lex-sort would pick v2, which would be wrong. Numeric
+    // comparison on the leading integer correctly returns v10.
     Optional<File> latest =
         IcebergMetadataUploaderService.pickLatestMetadataJson(
             Arrays.asList(
                 jsonFile("v1.metadata.json"),
                 jsonFile("v2.metadata.json"),
-                jsonFile("v10.metadata.json")));
+                jsonFile("v9.metadata.json"),
+                jsonFile("v10.metadata.json"),
+                jsonFile("v11.metadata.json")));
     assertTrue(latest.isPresent());
-    // Hadoop catalog convention is zero-padded in practice; bare integers sort poorly but we still
-    // pick *a* result deterministically. Document the limitation rather than hide it.
-    assertEquals("v2.metadata.json", latest.get().getFilename());
+    assertEquals("v11.metadata.json", latest.get().getFilename());
   }
 
   @Test
@@ -57,6 +60,48 @@ class TestIcebergMetadataUploaderService {
         IcebergMetadataUploaderService.pickLatestMetadataJson(
                 Collections.singletonList(
                     File.builder().filename("snap.avro").isDirectory(false).lastModifiedAt(Instant.EPOCH).build()))
+            .isPresent());
+  }
+
+  @Test
+  void extractVersionNumberHandlesAllNamingShapes() {
+    assertEquals(10L, IcebergMetadataUploaderService.extractVersionNumber("v10.metadata.json"));
+    assertEquals(20L, IcebergMetadataUploaderService.extractVersionNumber("00020-uuid.metadata.json"));
+    assertEquals(0L, IcebergMetadataUploaderService.extractVersionNumber("00000-uuid.metadata.json"));
+    // Non-numeric filenames still parse to -1 so they don't dominate the sort.
+    assertEquals(-1L, IcebergMetadataUploaderService.extractVersionNumber("metadata.json"));
+    assertEquals(-1L, IcebergMetadataUploaderService.extractVersionNumber("v.metadata.json"));
+  }
+
+  @Test
+  void resolveFromVersionHintReturnsTargetWhenPresent() {
+    Optional<File> resolved =
+        IcebergMetadataUploaderService.resolveFromVersionHint(
+            "7\n".getBytes(StandardCharsets.UTF_8),
+            Arrays.asList(
+                jsonFile("v6.metadata.json"),
+                jsonFile("v7.metadata.json"),
+                jsonFile("v8.metadata.json")));
+    assertTrue(resolved.isPresent());
+    assertEquals("v7.metadata.json", resolved.get().getFilename());
+  }
+
+  @Test
+  void resolveFromVersionHintReturnsEmptyWhenTargetMissing() {
+    // Hint points at v42 but only v6 / v7 exist — caller will fall back to numeric sort.
+    assertFalse(
+        IcebergMetadataUploaderService.resolveFromVersionHint(
+                "42".getBytes(StandardCharsets.UTF_8),
+                Arrays.asList(jsonFile("v6.metadata.json"), jsonFile("v7.metadata.json")))
+            .isPresent());
+  }
+
+  @Test
+  void resolveFromVersionHintReturnsEmptyOnNonIntegerContent() {
+    assertFalse(
+        IcebergMetadataUploaderService.resolveFromVersionHint(
+                "not-an-int".getBytes(StandardCharsets.UTF_8),
+                Collections.singletonList(jsonFile("v1.metadata.json")))
             .isPresent());
   }
 

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
@@ -3,16 +3,332 @@ package ai.onehouse.metadata_extractor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import ai.onehouse.api.OnehouseApiClient;
+import ai.onehouse.api.models.request.GenerateCommitMetadataUploadUrlRequest;
+import ai.onehouse.api.models.request.InitializeTableMetricsCheckpointRequest;
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.api.models.request.UpsertTableMetricsCheckpointRequest;
+import ai.onehouse.api.models.response.ApiResponse;
+import ai.onehouse.api.models.response.GenerateCommitMetadataUploadUrlResponse;
+import ai.onehouse.api.models.response.GetTableMetricsCheckpointResponse;
+import ai.onehouse.api.models.response.InitializeTableMetricsCheckpointResponse;
+import ai.onehouse.api.models.response.UpsertTableMetricsCheckpointResponse;
+import ai.onehouse.constants.MetricsConstants;
+import ai.onehouse.metadata_extractor.models.Checkpoint;
+import ai.onehouse.metadata_extractor.models.Table;
+import ai.onehouse.metrics.LakeViewExtractorMetrics;
+import ai.onehouse.storage.AsyncStorageClient;
+import ai.onehouse.storage.PresignedUrlFileUploader;
+import ai.onehouse.storage.StorageUtils;
 import ai.onehouse.storage.models.File;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class TestIcebergMetadataUploaderService {
+
+  private static final String TABLE_ID = "table-1";
+  private static final String TABLE_URI = "s3://bucket/db/t";
+  private static final String LAKE = "lake";
+  private static final String DATABASE = "db";
+
+  @Mock private OnehouseApiClient apiClient;
+  @Mock private AsyncStorageClient storageClient;
+  @Mock private PresignedUrlFileUploader uploader;
+  @Mock private LakeViewExtractorMetrics metrics;
+
+  private final StorageUtils storageUtils = new StorageUtils();
+  private final String metadataDir = storageUtils.constructFileUri(TABLE_URI, "metadata");
+  private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+  private IcebergMetadataUploaderService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new IcebergMetadataUploaderService(
+            storageClient, apiClient, uploader, storageUtils, metrics);
+  }
+
+  // ---------------------------------------------------------------------------
+  // uploadInstantsInTables / aggregation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void emptyTableSetCompletesTrueWithoutApiCalls() {
+    assertTrue(service.uploadInstantsInTables(Collections.emptySet()).join());
+    verifyNoInteractions(apiClient);
+    verifyNoInteractions(storageClient);
+  }
+
+  @Test
+  void multiTableOneFailureAggregatesToFalse() {
+    Table ok = icebergTable(TABLE_ID, null);
+    Table bad = icebergTable("table-2", null);
+    // table-1: up-to-date no-op (true). table-2: checkpoint fetch fails (false).
+    when(apiClient.getTableMetricsCheckpoints(Collections.singletonList(TABLE_ID)))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v1.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(completed(Collections.singletonList(jsonFile("v1.metadata.json"))));
+    when(apiClient.getTableMetricsCheckpoints(Collections.singletonList("table-2")))
+        .thenReturn(failed(new GetTableMetricsCheckpointResponse(), 500, "boom"));
+
+    assertFalse(service.uploadInstantsInTables(Set.of(ok, bad)).join());
+  }
+
+  // ---------------------------------------------------------------------------
+  // checkpoint fetch / parse
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void checkpointFetchFailureReturnsFalseAndIncrementsMetric() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(failed(new GetTableMetricsCheckpointResponse(), 503, "down"));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR), anyString());
+    verify(apiClient, never()).generateCommitMetadataUploadUrl(any());
+  }
+
+  @Test
+  void processTableExceptionIncrementsUnknownAndReturnsFalse() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("kaboom")));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.UNKNOWN), anyString());
+  }
+
+  @Test
+  void malformedCheckpointIsTreatedAsMissingAndInitialises() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, "{not-valid-json"));
+    when(apiClient.initializeTableMetricsCheckpoint(any())).thenReturn(initOk());
+    // INITIAL_CHECKPOINT has lastUploadedFile="", so v1 is new -> full upload.
+    stubFullUpload(Collections.singletonList(jsonFile("v1.metadata.json")));
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(apiClient)
+        .initializeTableMetricsCheckpoint(any(InitializeTableMetricsCheckpointRequest.class));
+  }
+
+  // ---------------------------------------------------------------------------
+  // initialise path
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void noCheckpointInitialisesThenUploads() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, null)); // blank checkpoint -> missing
+    when(apiClient.initializeTableMetricsCheckpoint(any())).thenReturn(initOk());
+    stubFullUpload(Collections.singletonList(jsonFile("v1.metadata.json")));
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(apiClient)
+        .initializeTableMetricsCheckpoint(any(InitializeTableMetricsCheckpointRequest.class));
+    verify(metrics).incrementMetadataUploadSuccessCounter();
+  }
+
+  @Test
+  void initFailureReturnsFalseAndIncrementsMetric() {
+    when(apiClient.getTableMetricsCheckpoints(anyList())).thenReturn(okCheckpoint(TABLE_ID, null));
+    when(apiClient.initializeTableMetricsCheckpoint(any()))
+        .thenReturn(failed(new InitializeTableMetricsCheckpointResponse(), 500, "init failed"));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR), anyString());
+    verify(apiClient, never()).generateCommitMetadataUploadUrl(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // fallback listing path
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void fallbackUpToDateIsNoOp() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v3.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(
+            completed(
+                Arrays.asList(jsonFile("v2.metadata.json"), jsonFile("v3.metadata.json"))));
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(apiClient, never()).generateCommitMetadataUploadUrl(any());
+  }
+
+  @Test
+  void fallbackAdvancesUploadsAndUpserts() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v2.metadata.json")));
+    stubFullUpload(Arrays.asList(jsonFile("v2.metadata.json"), jsonFile("v3.metadata.json")));
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(uploader).uploadFileToPresignedUrl(eq("https://presigned"), anyString(), anyInt());
+    verify(metrics).incrementMetadataUploadSuccessCounter();
+    verify(apiClient).upsertTableMetricsCheckpoint(any(UpsertTableMetricsCheckpointRequest.class));
+  }
+
+  @Test
+  void noMetadataJsonReturnsFalseWithNoSuchKey() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v1.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(completed(Collections.singletonList(jsonFile("README.md"))));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.NO_SUCH_KEY), anyString());
+  }
+
+  // ---------------------------------------------------------------------------
+  // version-hint.text resolution
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void versionHintResolvesTargetAndUploads() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v1.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(
+            completed(
+                Arrays.asList(
+                    jsonFile("version-hint.text"),
+                    jsonFile("v1.metadata.json"),
+                    jsonFile("v2.metadata.json"),
+                    jsonFile("v7.metadata.json"))));
+    when(storageClient.readFileAsBytes(
+            storageUtils.constructFileUri(metadataDir, "version-hint.text")))
+        .thenReturn(completed("7".getBytes(StandardCharsets.UTF_8)));
+    stubGenerateUpload();
+    when(apiClient.upsertTableMetricsCheckpoint(any())).thenReturn(upsertOk());
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(apiClient).generateCommitMetadataUploadUrl(argThatCommitInstantIs("v7.metadata.json"));
+  }
+
+  @Test
+  void versionHintReadFailureFallsBackToNumericSort() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v5.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(
+            completed(
+                Arrays.asList(
+                    jsonFile("version-hint.text"),
+                    jsonFile("v5.metadata.json"),
+                    jsonFile("v6.metadata.json"))));
+    when(storageClient.readFileAsBytes(anyString()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("read failed")));
+    stubGenerateUpload();
+    when(apiClient.upsertTableMetricsCheckpoint(any())).thenReturn(upsertOk());
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(apiClient).generateCommitMetadataUploadUrl(argThatCommitInstantIs("v6.metadata.json"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // metadataLocationHint fast path
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void hintPathUpToDateSkipsListing() {
+    String hint = "s3://bucket/db/t/metadata/v9.metadata.json";
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v9.metadata.json")));
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, hint))).join());
+    verify(storageClient, never()).listAllFilesInDir(anyString());
+    verify(apiClient, never()).generateCommitMetadataUploadUrl(any());
+  }
+
+  @Test
+  void hintPathUploadsWhenAdvancedWithoutListing() {
+    String hint = "s3a://bucket/db/t/metadata/v9.metadata.json";
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v8.metadata.json")));
+    stubGenerateUpload();
+    when(apiClient.upsertTableMetricsCheckpoint(any())).thenReturn(upsertOk());
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, hint))).join());
+    verify(storageClient, never()).listAllFilesInDir(anyString());
+    verify(uploader).uploadFileToPresignedUrl(eq("https://presigned"), eq(hint), anyInt());
+    verify(apiClient).generateCommitMetadataUploadUrl(argThatCommitInstantIs("v9.metadata.json"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // upload / upsert failure branches
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void presignedUrlFailureReturnsFalse() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v1.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(completed(Collections.singletonList(jsonFile("v2.metadata.json"))));
+    when(apiClient.generateCommitMetadataUploadUrl(any()))
+        .thenReturn(failed(new GenerateCommitMetadataUploadUrlResponse(), 500, "no url"));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.PRESIGNED_URL_UPLOAD_FAILURE),
+            anyString());
+    verify(uploader, never()).uploadFileToPresignedUrl(anyString(), anyString(), anyInt());
+  }
+
+  @Test
+  void upsertFailureReturnsFalseAfterSuccessfulUpload() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v1.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(completed(Collections.singletonList(jsonFile("v2.metadata.json"))));
+    stubGenerateUpload();
+    when(apiClient.upsertTableMetricsCheckpoint(any()))
+        .thenReturn(failed(new UpsertTableMetricsCheckpointResponse(), 500, "upsert failed"));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics).incrementMetadataUploadSuccessCounter(); // upload itself succeeded
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR), anyString());
+  }
+
+  // ===========================================================================
+  // Static helper tests (pure, no mocks)
+  // ===========================================================================
 
   @Test
   void picksLatestHiveGlueStyleMetadataJsonByNumericPrefix() {
@@ -28,8 +344,6 @@ class TestIcebergMetadataUploaderService {
 
   @Test
   void picksLatestHadoopCatalogMetadataJsonByVersionNumber() {
-    // v10 is numerically newer than v2 — lex-sort would pick v2, which would be wrong. Numeric
-    // comparison on the leading integer correctly returns v10.
     Optional<File> latest =
         IcebergMetadataUploaderService.pickLatestMetadataJson(
             Arrays.asList(
@@ -47,7 +361,7 @@ class TestIcebergMetadataUploaderService {
     Optional<File> latest =
         IcebergMetadataUploaderService.pickLatestMetadataJson(
             Arrays.asList(
-                File.builder().filename("snap-x.avro").isDirectory(false).lastModifiedAt(Instant.EPOCH).build(),
+                jsonFile("snap-x.avro"),
                 File.builder().filename("sub").isDirectory(true).lastModifiedAt(Instant.EPOCH).build(),
                 jsonFile("00001-a.metadata.json")));
     assertTrue(latest.isPresent());
@@ -58,17 +372,17 @@ class TestIcebergMetadataUploaderService {
   void returnsEmptyWhenNoMetadataJson() {
     assertFalse(
         IcebergMetadataUploaderService.pickLatestMetadataJson(
-                Collections.singletonList(
-                    File.builder().filename("snap.avro").isDirectory(false).lastModifiedAt(Instant.EPOCH).build()))
+                Collections.singletonList(jsonFile("snap.avro")))
             .isPresent());
   }
 
   @Test
   void extractVersionNumberHandlesAllNamingShapes() {
     assertEquals(10L, IcebergMetadataUploaderService.extractVersionNumber("v10.metadata.json"));
-    assertEquals(20L, IcebergMetadataUploaderService.extractVersionNumber("00020-uuid.metadata.json"));
-    assertEquals(0L, IcebergMetadataUploaderService.extractVersionNumber("00000-uuid.metadata.json"));
-    // Non-numeric filenames still parse to -1 so they don't dominate the sort.
+    assertEquals(
+        20L, IcebergMetadataUploaderService.extractVersionNumber("00020-uuid.metadata.json"));
+    assertEquals(
+        0L, IcebergMetadataUploaderService.extractVersionNumber("00000-uuid.metadata.json"));
     assertEquals(-1L, IcebergMetadataUploaderService.extractVersionNumber("metadata.json"));
     assertEquals(-1L, IcebergMetadataUploaderService.extractVersionNumber("v.metadata.json"));
   }
@@ -88,7 +402,6 @@ class TestIcebergMetadataUploaderService {
 
   @Test
   void resolveFromVersionHintReturnsEmptyWhenTargetMissing() {
-    // Hint points at v42 but only v6 / v7 exist — caller will fall back to numeric sort.
     assertFalse(
         IcebergMetadataUploaderService.resolveFromVersionHint(
                 "42".getBytes(StandardCharsets.UTF_8),
@@ -120,6 +433,96 @@ class TestIcebergMetadataUploaderService {
   @Test
   void lastPathSegmentReturnsInputWhenNoSlash() {
     assertEquals("filename.json", IcebergMetadataUploaderService.lastPathSegment("filename.json"));
+  }
+
+  // ===========================================================================
+  // helpers
+  // ===========================================================================
+
+  private static Set<Table> singleton(Table t) {
+    return Collections.singleton(t);
+  }
+
+  private static Table icebergTable(String tableId, String metadataLocationHint) {
+    return Table.builder()
+        .tableId(tableId)
+        .absoluteTableUri(TABLE_URI)
+        .lakeName(LAKE)
+        .databaseName(DATABASE)
+        .tableFormat(TableFormat.ICEBERG)
+        .metadataLocationHint(metadataLocationHint)
+        .build();
+  }
+
+  private String checkpointJson(String lastUploadedFile) {
+    Checkpoint checkpoint =
+        Checkpoint.builder()
+            .batchId(1)
+            .checkpointTimestamp(Instant.EPOCH)
+            .lastUploadedFile(lastUploadedFile)
+            .firstIncompleteCommitFile("")
+            .archivedCommitsProcessed(true)
+            .build();
+    try {
+      return mapper.writeValueAsString(checkpoint);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static CompletableFuture<GetTableMetricsCheckpointResponse> okCheckpoint(
+      String tableId, String checkpointJson) {
+    return completed(
+        GetTableMetricsCheckpointResponse.builder()
+            .checkpoints(
+                Collections.singletonList(
+                    GetTableMetricsCheckpointResponse.TableMetadataCheckpoint.builder()
+                        .tableId(tableId)
+                        .checkpoint(checkpointJson)
+                        .build()))
+            .build());
+  }
+
+  private static CompletableFuture<InitializeTableMetricsCheckpointResponse> initOk() {
+    return completed(InitializeTableMetricsCheckpointResponse.builder().build());
+  }
+
+  private static CompletableFuture<UpsertTableMetricsCheckpointResponse> upsertOk() {
+    return completed(UpsertTableMetricsCheckpointResponse.builder().build());
+  }
+
+  /** Stubs generate-url (one presigned URL) + a successful presigned PUT. */
+  private void stubGenerateUpload() {
+    when(apiClient.generateCommitMetadataUploadUrl(any()))
+        .thenReturn(
+            completed(
+                GenerateCommitMetadataUploadUrlResponse.builder()
+                    .uploadUrls(Collections.singletonList("https://presigned"))
+                    .build()));
+    when(uploader.uploadFileToPresignedUrl(anyString(), anyString(), anyInt()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+  }
+
+  /** Stubs the full happy-path: list metadata/, generate url, upload, upsert. */
+  private void stubFullUpload(List<File> metadataListing) {
+    when(storageClient.listAllFilesInDir(metadataDir)).thenReturn(completed(metadataListing));
+    stubGenerateUpload();
+    when(apiClient.upsertTableMetricsCheckpoint(any())).thenReturn(upsertOk());
+  }
+
+  private static GenerateCommitMetadataUploadUrlRequest argThatCommitInstantIs(String filename) {
+    return ArgumentMatchers.argThat(
+        req -> req != null && req.getCommitInstants().contains(filename));
+  }
+
+  private static <T> CompletableFuture<T> completed(T value) {
+    return CompletableFuture.completedFuture(value);
+  }
+
+  private static <T extends ApiResponse> CompletableFuture<T> failed(
+      T response, int statusCode, String cause) {
+    response.setError(statusCode, cause);
+    return CompletableFuture.completedFuture(response);
   }
 
   private static File jsonFile(String name) {

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
@@ -34,6 +34,7 @@ import ai.onehouse.storage.models.File;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.common.collect.ImmutableSet;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
@@ -98,7 +99,7 @@ class TestIcebergMetadataUploaderService {
     when(apiClient.getTableMetricsCheckpoints(Collections.singletonList("table-2")))
         .thenReturn(failed(new GetTableMetricsCheckpointResponse(), 500, "boom"));
 
-    assertFalse(service.uploadInstantsInTables(Set.of(ok, bad)).join());
+    assertFalse(service.uploadInstantsInTables(ImmutableSet.of(ok, bad)).join());
   }
 
   // ---------------------------------------------------------------------------
@@ -120,7 +121,7 @@ class TestIcebergMetadataUploaderService {
   @Test
   void processTableExceptionIncrementsUnknownAndReturnsFalse() {
     when(apiClient.getTableMetricsCheckpoints(anyList()))
-        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("kaboom")));
+        .thenReturn(failedFuture(new RuntimeException("kaboom")));
 
     assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
     verify(metrics)
@@ -251,7 +252,7 @@ class TestIcebergMetadataUploaderService {
                     jsonFile("v5.metadata.json"),
                     jsonFile("v6.metadata.json"))));
     when(storageClient.readFileAsBytes(anyString()))
-        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("read failed")));
+        .thenReturn(failedFuture(new RuntimeException("read failed")));
     stubGenerateUpload();
     when(apiClient.upsertTableMetricsCheckpoint(any())).thenReturn(upsertOk());
 
@@ -517,6 +518,12 @@ class TestIcebergMetadataUploaderService {
 
   private static <T> CompletableFuture<T> completed(T value) {
     return CompletableFuture.completedFuture(value);
+  }
+
+  private static <T> CompletableFuture<T> failedFuture(Throwable error) {
+    CompletableFuture<T> future = new CompletableFuture<>();
+    future.completeExceptionally(error);
+    return future;
   }
 
   private static <T extends ApiResponse> CompletableFuture<T> failed(

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
@@ -1,0 +1,45 @@
+package ai.onehouse.metadata_extractor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.models.File;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class TestIcebergTableFormatDetector {
+  private final IcebergTableFormatDetector detector = new IcebergTableFormatDetector();
+
+  @Test
+  void declaresIcebergFormat() {
+    assertEquals(TableFormat.ICEBERG, detector.format());
+  }
+
+  @Test
+  void matchesWhenMetadataDirectoryPresent() {
+    assertTrue(
+        detector.matches(
+            Arrays.asList(file("metadata", true), file("data", true))));
+  }
+
+  @Test
+  void doesNotMatchOnFileNamedMetadata() {
+    // A non-directory entry named "metadata" must not be confused with the metadata/ folder.
+    assertFalse(detector.matches(Collections.singletonList(file("metadata", false))));
+  }
+
+  @Test
+  void doesNotMatchOnHudiLayout() {
+    assertFalse(
+        detector.matches(
+            Arrays.asList(file(".hoodie", true), file("part-0.parquet", false))));
+  }
+
+  private static File file(String name, boolean dir) {
+    return File.builder().filename(name).isDirectory(dir).lastModifiedAt(Instant.EPOCH).build();
+  }
+}

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
@@ -3,16 +3,37 @@ package ai.onehouse.metadata_extractor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.AsyncStorageClient;
+import ai.onehouse.storage.StorageUtils;
 import ai.onehouse.storage.models.File;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class TestIcebergTableFormatDetector {
-  private final IcebergTableFormatDetector detector = new IcebergTableFormatDetector();
+  private static final String TABLE_PATH = "s3://bucket/db/t";
+  private static final String METADATA_PATH = "s3://bucket/db/t/metadata";
+
+  @Mock private AsyncStorageClient asyncStorageClient;
+  private IcebergTableFormatDetector detector;
+
+  @BeforeEach
+  void setUp() {
+    detector = new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils());
+  }
 
   @Test
   void declaresIcebergFormat() {
@@ -20,23 +41,48 @@ class TestIcebergTableFormatDetector {
   }
 
   @Test
-  void matchesWhenMetadataDirectoryPresent() {
+  void matchesWhenMetadataDirHasMetadataJson() {
+    when(asyncStorageClient.listAllFilesInDir(eq(METADATA_PATH)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(
+                    file("v3.metadata.json", false),
+                    file("snap-1.avro", false))));
     assertTrue(
-        detector.matches(
-            Arrays.asList(file("metadata", true), file("data", true))));
+        detector
+            .matches(TABLE_PATH, Arrays.asList(file("metadata", true), file("data", true)))
+            .join());
+  }
+
+  @Test
+  void doesNotMatchWhenMetadataDirEmptyOfMetadataJson() {
+    // Real false-positive: a folder happens to have a `metadata/` subdir but no Iceberg pointer.
+    when(asyncStorageClient.listAllFilesInDir(eq(METADATA_PATH)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(file("schema.csv", false), file("README.md", false))));
+    assertFalse(
+        detector
+            .matches(TABLE_PATH, Arrays.asList(file("metadata", true), file("data", true)))
+            .join());
   }
 
   @Test
   void doesNotMatchOnFileNamedMetadata() {
-    // A non-directory entry named "metadata" must not be confused with the metadata/ folder.
-    assertFalse(detector.matches(Collections.singletonList(file("metadata", false))));
+    // A non-directory entry named "metadata" must not be confused with the metadata/ folder, and
+    // we must not issue the validating LIST when the marker isn't present.
+    assertFalse(
+        detector.matches(TABLE_PATH, Collections.singletonList(file("metadata", false))).join());
+    verify(asyncStorageClient, never()).listAllFilesInDir(eq(METADATA_PATH));
   }
 
   @Test
   void doesNotMatchOnHudiLayout() {
     assertFalse(
-        detector.matches(
-            Arrays.asList(file(".hoodie", true), file("part-0.parquet", false))));
+        detector
+            .matches(TABLE_PATH, Arrays.asList(file(".hoodie", true), file("part-0.parquet", false)))
+            .join());
+    verify(asyncStorageClient, never()).listAllFilesInDir(eq(METADATA_PATH));
   }
 
   private static File file(String name, boolean dir) {

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
@@ -85,6 +85,21 @@ class TestIcebergTableFormatDetector {
     verify(asyncStorageClient, never()).listAllFilesInDir(eq(METADATA_PATH));
   }
 
+  @Test
+  void matchesWhenMetadataDirEntryHasTrailingSlash() {
+    // S3 ListObjectsV2 returns CommonPrefixes as e.g. "metadata/" (with the trailing slash that
+    // S3 itself uses). The storage client may surface that filename verbatim, so the detector
+    // must accept both "metadata" and "metadata/" as the folder marker.
+    when(asyncStorageClient.listAllFilesInDir(eq(METADATA_PATH)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Collections.singletonList(file("00000-uuid.metadata.json", false))));
+    assertTrue(
+        detector
+            .matches(TABLE_PATH, Collections.singletonList(file("metadata/", true)))
+            .join());
+  }
+
   private static File file(String name, boolean dir) {
     return File.builder().filename(name).isDirectory(dir).lastModifiedAt(Instant.EPOCH).build();
   }

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
@@ -3,7 +3,6 @@ package ai.onehouse.metadata_extractor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,7 +41,7 @@ class TestIcebergTableFormatDetector {
 
   @Test
   void matchesWhenMetadataDirHasMetadataJson() {
-    when(asyncStorageClient.listAllFilesInDir(eq(METADATA_PATH)))
+    when(asyncStorageClient.listAllFilesInDir(METADATA_PATH))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Arrays.asList(
@@ -57,7 +56,7 @@ class TestIcebergTableFormatDetector {
   @Test
   void doesNotMatchWhenMetadataDirEmptyOfMetadataJson() {
     // Real false-positive: a folder happens to have a `metadata/` subdir but no Iceberg pointer.
-    when(asyncStorageClient.listAllFilesInDir(eq(METADATA_PATH)))
+    when(asyncStorageClient.listAllFilesInDir(METADATA_PATH))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Arrays.asList(file("schema.csv", false), file("README.md", false))));
@@ -73,7 +72,7 @@ class TestIcebergTableFormatDetector {
     // we must not issue the validating LIST when the marker isn't present.
     assertFalse(
         detector.matches(TABLE_PATH, Collections.singletonList(file("metadata", false))).join());
-    verify(asyncStorageClient, never()).listAllFilesInDir(eq(METADATA_PATH));
+    verify(asyncStorageClient, never()).listAllFilesInDir(METADATA_PATH);
   }
 
   @Test
@@ -82,7 +81,7 @@ class TestIcebergTableFormatDetector {
         detector
             .matches(TABLE_PATH, Arrays.asList(file(".hoodie", true), file("part-0.parquet", false)))
             .join());
-    verify(asyncStorageClient, never()).listAllFilesInDir(eq(METADATA_PATH));
+    verify(asyncStorageClient, never()).listAllFilesInDir(METADATA_PATH);
   }
 
   @Test
@@ -90,7 +89,7 @@ class TestIcebergTableFormatDetector {
     // S3 ListObjectsV2 returns CommonPrefixes as e.g. "metadata/" (with the trailing slash that
     // S3 itself uses). The storage client may surface that filename verbatim, so the detector
     // must accept both "metadata" and "metadata/" as the folder marker.
-    when(asyncStorageClient.listAllFilesInDir(eq(METADATA_PATH)))
+    when(asyncStorageClient.listAllFilesInDir(METADATA_PATH))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Collections.singletonList(file("00000-uuid.metadata.json", false))));

--- a/lakeview/src/test/java/ai/onehouse/storage/StorageUtilsTest.java
+++ b/lakeview/src/test/java/ai/onehouse/storage/StorageUtilsTest.java
@@ -10,6 +10,9 @@ class StorageUtilsTest {
   @Test
   void testGetPathFromUrl() {
     assertEquals("path/to/file", storageUtils.getPathFromUrl("s3://bucket/path/to/file"));
+    // s3a:// is the Hadoop scheme used by the iceberg/Glue metadata_location values the agent
+    // writes into Firestore — IcebergMetadataUploaderService must be able to parse these.
+    assertEquals("path/to/file", storageUtils.getPathFromUrl("s3a://bucket/path/to/file"));
     assertEquals("path/to/file", storageUtils.getPathFromUrl("gs://bucket/path/to/file"));
     assertEquals(
         "path/to/file",
@@ -24,6 +27,7 @@ class StorageUtilsTest {
         storageUtils.getPathFromUrl(
             "abfss://container@account.dfs.core.windows.net/path/to/file"));
     assertEquals("", storageUtils.getPathFromUrl("s3://bucket"));
+    assertEquals("", storageUtils.getPathFromUrl("s3a://bucket"));
     assertEquals("", storageUtils.getPathFromUrl("gs://bucket"));
     assertEquals(
         "", storageUtils.getPathFromUrl("https://account.blob.core.windows.net/container"));
@@ -110,6 +114,9 @@ class StorageUtilsTest {
   @Test
   void testGetBucketNameFromUri() {
     assertEquals("bucket", storageUtils.getBucketNameFromUri("s3://bucket/path/to/file"));
+    // s3a:// must resolve to the same bucket as s3:// — IcebergMetadataUploaderService passes
+    // the s3a:// metadata_location verbatim through this method.
+    assertEquals("bucket", storageUtils.getBucketNameFromUri("s3a://bucket/path/to/file"));
     assertEquals("bucket", storageUtils.getBucketNameFromUri("gs://bucket/path/to/file"));
     assertEquals(
         "container",
@@ -128,6 +135,7 @@ class StorageUtilsTest {
         storageUtils.getBucketNameFromUri(
             "abfss://container@account.dfs.core.windows.net/path/to/file"));
     assertEquals("bucket", storageUtils.getBucketNameFromUri("s3://bucket"));
+    assertEquals("bucket", storageUtils.getBucketNameFromUri("s3a://bucket"));
     assertEquals("bucket", storageUtils.getBucketNameFromUri("gs://bucket"));
     assertEquals(
         "container",


### PR DESCRIPTION
## Summary

Teaches LakeView to detect Iceberg table roots (the `metadata/` folder) in addition to Hudi (`.hoodie/`), and upload the current `metadata.json` pointer file to the Onehouse temp bucket on each iteration. The control plane parses the snapshot summary (which carries cumulative `total-records`, `total-files-size`, `total-data-files`, per-snapshot deltas, and the `snapshot-log[]` history) — gateway-controller side is a separate PR.

See [`docs/iceberg-support.md`](docs/iceberg-support.md) for the full design.

## Abstractions

- **`TableFormatDetector` SPI** with `HudiTableFormatDetector` (existing `.hoodie/` check moved out of `TableDiscoveryService.isHudiTableFolder`) and `IcebergTableFormatDetector` (matches when a directory listing contains a `metadata/` subdirectory **and** that subdirectory holds a `*.metadata.json`). `TableDiscoveryService` picks the single detector matching each `Database`'s declared `tableFormat` and tags each discovered `Table` with its format.
- **`IcebergMetadataUploaderService`** as a sibling of `TableMetadataUploaderService` rather than a branch inside it. Hudi's active/archived timeline distinction, `hoodie.properties` bootstrap, and LSM manifest plumbing don't apply to Iceberg, so a separate service is clearer than a branching megaclass. It reuses `OnehouseApiClient`, `PresignedUrlFileUploader`, `AsyncStorageClient`, and `StorageUtils` directly.
- **`TableDiscoveryAndUploadJob.dispatchUpload`** partitions discovered tables by format and runs the two uploaders concurrently; both `runOnce` and `processTables` route through it.

## Wire

- New `TableFormat` enum (`HUDI`, `ICEBERG`) in `api/models/request/`, JSON-aliased to the proto enum names (`TABLE_FORMAT_HUDI` / `TABLE_FORMAT_ICEBERG`) so the control-plane parser accepts the value.
- `Table` model gains `tableFormat` (defaults to `HUDI` for backward compat).
- `InitializeSingleTableMetricsCheckpointRequest` gains a nullable `tableFormat`. Server treats absent as `HUDI`. `tableType` (COW/MOR) stays `@NonNull` to preserve the existing wire contract; Iceberg init passes `COW` as a meaningless placeholder since the server discriminates on `tableFormat` first.
- `s3a://` accepted by `OBJECT_STORAGE_URI_PATTERN` alongside `s3://` (Glue `metadata_location` scheme).

## Selecting the current `metadata.json`

Exactly one file is uploaded per iteration — the current `metadata.json` — resolved through three paths in order of preference:

1. **`metadataLocationHint`** from the parser YAML's table hints (catalog-driven, e.g. Glue `metadata_location`): PUT the file directly, skip the listing. Only applies to `#tableId`-pinned base paths.
2. **`metadata/version-hint.text`** (Hadoop catalog): its integer content names the current `v{N}.metadata.json` unambiguously.
3. **Numeric-aware filename comparison** (last resort): the leading integer in the filename (after an optional `v` prefix) is the version number — correct for both `v{N}.metadata.json` (Hadoop) and `00000-<uuid>.metadata.json` (Hive/Glue/Spark) without depending on zero-padding. ⚠️ This can select an uncommitted `metadata.json` if neither a hint nor `version-hint.text` is present; paths 1–2 are authoritative.

Checkpoint tracks the last uploaded filename; if it hasn't changed since last run, the iteration is a no-op.

## Deployment ordering ⚠️

This change spans three repos and **must roll out in order**:

1. **idls** — `TableFormat` proto enum / `TableMetricsCheckpoint` field ([idls PR #1939](https://github.com/onehouseinc/idls/pull/1939), `80d81701`).
2. **gateway-controller** — `IcebergCommitMetadataParser` parses the uploaded `metadata.json` and emits to OpenSearch.
3. **LakeView** (this PR).

If LakeView ships before the server understands `tableFormat`, the server-side protobuf JSON parser drops the unknown enum value and persists `TABLE_FORMAT_INVALID`, routing Iceberg uploads through the Hudi back-compat fallback. **Do not deploy this until the running control plane tolerates `tableFormat=ICEBERG` cleanly.** See the deploy-ordering section of `docs/iceberg-support.md`.

## Test plan

- [x] `./gradlew :lakeview:test --tests "ai.onehouse.metadata_extractor.*"` green locally
- [x] Instance-pipeline coverage for `IcebergMetadataUploaderService` (~97% line) + detector pairs + `dispatchUpload` routing
- [x] Existing `TableDiscoveryServiceTest` / `TableDiscoveryAndUploadJobTest` pass after constructor signature changes
- [ ] CI green
- [ ] Manual: end-to-end against `s3://aadsharma-quanton-test/spark4_iceberg_variant.db/t_variant_1/` once control-plane parser lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
