### PR TITLE
[ENG-41614] Introduce TableFormatDetector SPI (Hudi-only)

### DIFF
--- a/lakeview-sync-tool/src/main/java/ai/onehouse/lakeview/sync/LakeviewSyncTool.java
+++ b/lakeview-sync-tool/src/main/java/ai/onehouse/lakeview/sync/LakeviewSyncTool.java
@@ -14,6 +14,7 @@ import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.config.models.configv1.ParserConfig;
 import ai.onehouse.metadata_extractor.ActiveTimelineInstantBatcher;
 import ai.onehouse.metadata_extractor.HoodiePropertiesReader;
+import ai.onehouse.metadata_extractor.HudiTableFormatDetector;
 import ai.onehouse.metadata_extractor.LSMTimelineManifestReader;
 import ai.onehouse.metadata_extractor.TableDiscoveryAndUploadJob;
 import ai.onehouse.metadata_extractor.TableDiscoveryService;
@@ -253,7 +254,7 @@ public class LakeviewSyncTool extends HoodieSyncTool implements AutoCloseable {
         configProvider);
 
     TableDiscoveryService tableDiscoveryService = new TableDiscoveryService(asyncStorageClient, storageUtils,
-            configProvider, executorService, lakeViewExtractorMetrics);
+            configProvider, executorService, lakeViewExtractorMetrics, new HudiTableFormatDetector());
     HoodiePropertiesReader hoodiePropertiesReader = new HoodiePropertiesReader(asyncStorageClient,
         lakeViewExtractorMetrics);
     OnehouseApiClient onehouseApiClient = new OnehouseApiClient(asyncHttpClientWithRetry, config,

--- a/lakeview/src/main/java/ai/onehouse/api/models/request/TableFormat.java
+++ b/lakeview/src/main/java/ai/onehouse/api/models/request/TableFormat.java
@@ -1,0 +1,20 @@
+package ai.onehouse.api.models.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Physical observed-table format. Wire-serialized to the protobuf enum names defined in
+ * lake/table.proto's {@code TableFormat} so the control plane's protobuf-java-util JSON parser
+ * accepts the value on RPCs like {@code InitializeTableMetricsCheckpoint}. Without these
+ * {@code @JsonProperty} aliases, Jackson would emit the short Java identifier ({@code "ICEBERG"})
+ * and the server-side parser — which requires the canonical proto enum name
+ * ({@code "TABLE_FORMAT_ICEBERG"}) — would silently drop the value and persist the checkpoint
+ * with the proto enum-zero default ({@code TABLE_FORMAT_INVALID}), routing iceberg uploads
+ * through the Hudi back-compat fallback.
+ */
+public enum TableFormat {
+  @JsonProperty("TABLE_FORMAT_HUDI")
+  HUDI,
+  @JsonProperty("TABLE_FORMAT_ICEBERG")
+  ICEBERG
+}

--- a/lakeview/src/main/java/ai/onehouse/config/models/configv1/Database.java
+++ b/lakeview/src/main/java/ai/onehouse/config/models/configv1/Database.java
@@ -1,6 +1,8 @@
 package ai.onehouse.config.models.configv1;
 
+import ai.onehouse.api.models.request.TableFormat;
 import java.util.List;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -12,4 +14,11 @@ import lombok.extern.jackson.Jacksonized;
 public class Database {
   String name;
   @NonNull List<String> basePaths;
+  /**
+   * Physical table format of the tables under {@link #basePaths}. Null is interpreted as {@link
+   * TableFormat#HUDI} for backward compatibility with YAMLs written before format-aware
+   * discovery existed. Customers with a mixed-format warehouse should split into separate {@link
+   * Database} entries, one per format.
+   */
+  @Nullable TableFormat tableFormat;
 }

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/HudiTableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/HudiTableFormatDetector.java
@@ -1,0 +1,22 @@
+package ai.onehouse.metadata_extractor;
+
+import static ai.onehouse.constants.MetadataExtractorConstants.HOODIE_FOLDER_NAME;
+
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.models.File;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/** A directory is a Hudi table root if it contains a {@code .hoodie/} folder. */
+public class HudiTableFormatDetector implements TableFormatDetector {
+  @Override
+  public TableFormat format() {
+    return TableFormat.HUDI;
+  }
+
+  @Override
+  public CompletableFuture<Boolean> matches(String path, List<File> listedFiles) {
+    return CompletableFuture.completedFuture(
+        listedFiles.stream().anyMatch(file -> file.getFilename().startsWith(HOODIE_FOLDER_NAME)));
+  }
+}

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -183,7 +183,7 @@ public class TableDiscoveryService {
                             List<File> directories =
                                 listedFiles.stream()
                                     .filter(File::isDirectory)
-                                    .collect(Collectors.toUnmodifiableList());
+                                    .collect(Collectors.toList());
 
                             List<CompletableFuture<Void>> recursiveFutures = new ArrayList<>();
                             for (File file : directories) {

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -183,7 +183,7 @@ public class TableDiscoveryService {
                             List<File> directories =
                                 listedFiles.stream()
                                     .filter(File::isDirectory)
-                                    .collect(Collectors.toList());
+                                    .collect(Collectors.toUnmodifiableList());
 
                             List<CompletableFuture<Void>> recursiveFutures = new ArrayList<>();
                             for (File file : directories) {

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -1,24 +1,26 @@
 package ai.onehouse.metadata_extractor;
 
-import static ai.onehouse.constants.MetadataExtractorConstants.HOODIE_FOLDER_NAME;
 import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataExtractorFailureReason;
 import static java.util.Collections.emptySet;
 
-import com.google.inject.Inject;
-import ai.onehouse.constants.MetricsConstants;
+import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
+import ai.onehouse.api.models.request.TableFormat;
 import ai.onehouse.config.ConfigProvider;
 import ai.onehouse.config.models.configv1.Database;
 import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.config.models.configv1.ParserConfig;
+import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.metadata_extractor.models.Table;
 import ai.onehouse.metrics.LakeViewExtractorMetrics;
 import ai.onehouse.storage.AsyncStorageClient;
 import ai.onehouse.storage.StorageUtils;
 import ai.onehouse.storage.models.File;
-import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,8 +32,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 /*
- * Discovers hudi tables by Parsing all folders (including nested folders) in provided base paths
- * excluded paths will be skipped.
+ * Discovers tables by walking all folders (including nested folders) in provided base paths.
+ * Each {@link Database} in the parser YAML declares its {@code tableFormat}; this service picks
+ * the single {@link TableFormatDetector} matching that format and applies it to every directory
+ * under the database's base paths. Excluded paths are skipped.
  */
 @Slf4j
 public class TableDiscoveryService {
@@ -41,6 +45,7 @@ public class TableDiscoveryService {
   private final ExecutorService executorService;
   private final ConfigProvider configProvider;
   private final LakeViewExtractorMetrics lakeviewExtractorMetrics;
+  private final Map<TableFormat, TableFormatDetector> detectorsByFormat;
 
   @Inject
   public TableDiscoveryService(
@@ -48,12 +53,14 @@ public class TableDiscoveryService {
       @Nonnull StorageUtils storageUtils,
       @Nonnull ConfigProvider configProvider,
       @Nonnull ExecutorService executorService,
-      @Nonnull LakeViewExtractorMetrics lakeviewExtractorMetrics) {
+      @Nonnull LakeViewExtractorMetrics lakeviewExtractorMetrics,
+      @Nonnull HudiTableFormatDetector hudiTableFormatDetector) {
     this.asyncStorageClient = asyncStorageClient;
     this.storageUtils = storageUtils;
     this.executorService = executorService;
     this.configProvider = configProvider;
     this.lakeviewExtractorMetrics = lakeviewExtractorMetrics;
+    this.detectorsByFormat = ImmutableMap.of(TableFormat.HUDI, hudiTableFormatDetector);
   }
 
   public CompletableFuture<Set<Table>> discoverTables() {
@@ -67,6 +74,7 @@ public class TableDiscoveryService {
 
     for (ParserConfig parserConfig : metadataExtractorConfig.getParserConfig()) {
       for (Database database : parserConfig.getDatabases()) {
+        TableFormatDetector detector = detectorFor(database);
         for (String basePathConfig : database.getBasePaths()) {
           String basePath = extractBasePath(basePathConfig);
 
@@ -78,7 +86,11 @@ public class TableDiscoveryService {
               Pair.of(
                   basePathConfig,
                   discoverTablesInPath(
-                      basePath, parserConfig.getLake(), database.getName(), excludedPathPatterns)));
+                      basePath,
+                      parserConfig.getLake(),
+                      database.getName(),
+                      excludedPathPatterns,
+                      detector)));
         }
       }
     }
@@ -116,6 +128,18 @@ public class TableDiscoveryService {
             });
   }
 
+  private TableFormatDetector detectorFor(Database database) {
+    TableFormat declared =
+        database.getTableFormat() == null ? TableFormat.HUDI : database.getTableFormat();
+    TableFormatDetector detector = detectorsByFormat.get(declared);
+    if (detector == null) {
+      // Programmer error: a TableFormat enum value was added without a matching detector. With
+      // only HUDI registered today, this fires if a YAML declares any other format.
+      throw new IllegalStateException("No detector registered for tableFormat=" + declared);
+    }
+    return detector;
+  }
+
   private String extractBasePath(String basePathConfig) {
     String[] basePathConfigParts = basePathConfig.split(TABLE_ID_SEPARATOR);
     return basePathConfigParts[0];
@@ -127,68 +151,75 @@ public class TableDiscoveryService {
   }
 
   private CompletableFuture<Set<Table>> discoverTablesInPath(
-      String path, String lakeName, String databaseName, List<String> excludedPathPatterns) {
+      String path,
+      String lakeName,
+      String databaseName,
+      List<String> excludedPathPatterns,
+      TableFormatDetector detector) {
     try {
       log.info(String.format("Discovering tables in %s", path));
       return asyncStorageClient
           .listAllFilesInDir(path)
           .thenComposeAsync(
-              listedFiles -> {
-                Set<Table> tablePaths = ConcurrentHashMap.newKeySet();
-                List<CompletableFuture<Void>> recursiveFutures = new ArrayList<>();
+              listedFiles ->
+                  detector
+                      .matches(path, listedFiles)
+                      .thenComposeAsync(
+                          matched -> {
+                            Set<Table> tablePaths = ConcurrentHashMap.newKeySet();
+                            if (Boolean.TRUE.equals(matched)) {
+                              Table table =
+                                  Table.builder()
+                                      .absoluteTableUri(path)
+                                      .databaseName(databaseName)
+                                      .lakeName(lakeName)
+                                      .build();
+                              if (!isExcluded(table.getAbsoluteTableUri(), excludedPathPatterns)) {
+                                tablePaths.add(table);
+                              }
+                              return CompletableFuture.completedFuture(tablePaths);
+                            }
 
-                if (isHudiTableFolder(listedFiles)) {
-                  Table table =
-                      Table.builder()
-                          .absoluteTableUri(path)
-                          .databaseName(databaseName)
-                          .lakeName(lakeName)
-                          .build();
-                  if (!isExcluded(table.getAbsoluteTableUri(), excludedPathPatterns)) {
-                    tablePaths.add(table);
-                  }
-                  return CompletableFuture.completedFuture(tablePaths);
-                }
+                            List<File> directories =
+                                listedFiles.stream()
+                                    .filter(File::isDirectory)
+                                    .collect(Collectors.toList());
 
-                List<File> directories =
-                    listedFiles.stream().filter(File::isDirectory).collect(Collectors.toList());
+                            List<CompletableFuture<Void>> recursiveFutures = new ArrayList<>();
+                            for (File file : directories) {
+                              String filePath =
+                                  storageUtils.constructFileUri(path, file.getFilename());
+                              if (!isExcluded(filePath, excludedPathPatterns)) {
+                                CompletableFuture<Void> recursiveFuture =
+                                    discoverTablesInPath(
+                                            filePath,
+                                            lakeName,
+                                            databaseName,
+                                            excludedPathPatterns,
+                                            detector)
+                                        .thenAccept(tablePaths::addAll);
+                                recursiveFutures.add(recursiveFuture);
+                              }
+                            }
 
-                for (File file : directories) {
-                  String filePath = storageUtils.constructFileUri(path, file.getFilename());
-                  if (!isExcluded(filePath, excludedPathPatterns)) {
-                    CompletableFuture<Void> recursiveFuture =
-                        discoverTablesInPath(filePath, lakeName, databaseName, excludedPathPatterns)
-                            .thenAccept(tablePaths::addAll);
-                    recursiveFutures.add(recursiveFuture);
-                  }
-                }
-
-                return CompletableFuture.allOf(recursiveFutures.toArray(new CompletableFuture[0]))
-                    .thenApplyAsync(ignored -> tablePaths, executorService);
-              },
+                            return CompletableFuture.allOf(
+                                    recursiveFutures.toArray(new CompletableFuture[0]))
+                                .thenApplyAsync(ignored -> tablePaths, executorService);
+                          },
+                          executorService),
               executorService)
           .exceptionally(
               e -> {
                 log.error("Failed to discover tables in path: {}", path, e);
                 lakeviewExtractorMetrics.incrementTableDiscoveryFailureCounter(
-                  getMetadataExtractorFailureReason(
-                    e,
-                    MetricsConstants.MetadataUploadFailureReasons.UNKNOWN)
-                );
+                    getMetadataExtractorFailureReason(
+                        e, MetricsConstants.MetadataUploadFailureReasons.UNKNOWN));
                 return emptySet();
               });
     } catch (Exception e) {
       log.error("Failed to discover tables in path: {}", path, e);
       return CompletableFuture.completedFuture(emptySet());
     }
-  }
-
-  /*
-   *  checks the contents of a folder to see if it is a hudi table or not
-   *  a folder is a hudi table if it contains .hoodie folder within it
-   */
-  private static boolean isHudiTableFolder(List<File> listedFiles) {
-    return listedFiles.stream().anyMatch(file -> file.getFilename().startsWith(HOODIE_FOLDER_NAME));
   }
 
   private boolean isExcluded(String filePath, List<String> excludedPathPatterns) {

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableFormatDetector.java
@@ -1,0 +1,31 @@
+package ai.onehouse.metadata_extractor;
+
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.models.File;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Identifies whether a directory listing represents the root of a table of a particular format.
+ *
+ * <p>One implementation per supported format (Hudi, Iceberg, ...). Each {@code Database} in the
+ * parser YAML declares its {@code tableFormat}, and {@link TableDiscoveryService} picks the
+ * single matching detector for that database — detectors are not raced against each other, so
+ * there is no ordering trap.
+ *
+ * <p>{@link #matches} returns a {@link CompletableFuture} because some detectors need a follow-up
+ * directory listing to confirm a match (e.g. Iceberg's "must have a {@code *.metadata.json}
+ * inside {@code metadata/}" rule). Stateless detectors should return {@link
+ * CompletableFuture#completedFuture}.
+ */
+public interface TableFormatDetector {
+  /** Format this detector identifies. */
+  TableFormat format();
+
+  /**
+   * Returns true if the directory at {@code path} (with its top-level listing already in {@code
+   * listedFiles}) is a table root of {@link #format()}. Implementations may issue additional
+   * storage I/O to validate.
+   */
+  CompletableFuture<Boolean> matches(String path, List<File> listedFiles);
+}

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
@@ -164,7 +164,8 @@ class TableDiscoveryServiceTest {
             new StorageUtils(),
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
-            hudiMetadataExtractorMetrics);
+            hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector());
 
     Set<Table> tableSet = tableDiscoveryService.discoverTables().get();
     List<Table> expectedResponseSet =
@@ -256,7 +257,8 @@ class TableDiscoveryServiceTest {
             new StorageUtils(),
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
-            hudiMetadataExtractorMetrics);
+            hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector());
 
     Set<Table> discoveredTables = tableDiscoveryService.discoverTables().join();
     assertEquals(emptySet(), discoveredTables);
@@ -294,7 +296,8 @@ class TableDiscoveryServiceTest {
             new StorageUtils(),
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
-            hudiMetadataExtractorMetrics);
+            hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector());
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
   }
 
@@ -326,7 +329,8 @@ class TableDiscoveryServiceTest {
             new StorageUtils(),
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
-            hudiMetadataExtractorMetrics);
+            hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector());
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
   }
 
@@ -357,7 +361,8 @@ class TableDiscoveryServiceTest {
                     new StorageUtils(),
                     new ConfigProvider(config),
                     ForkJoinPool.commonPool(),
-                    hudiMetadataExtractorMetrics);
+                    hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector());
 
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
 

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestHudiTableFormatDetector.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestHudiTableFormatDetector.java
@@ -1,0 +1,52 @@
+package ai.onehouse.metadata_extractor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.models.File;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class TestHudiTableFormatDetector {
+  private static final String ANY_PATH = "s3://bucket/db/t/";
+  private final HudiTableFormatDetector detector = new HudiTableFormatDetector();
+
+  @Test
+  void declaresHudiFormat() {
+    assertEquals(TableFormat.HUDI, detector.format());
+  }
+
+  @Test
+  void matchesWhenHoodieFolderPresent() {
+    assertTrue(
+        detector
+            .matches(
+                ANY_PATH,
+                Arrays.asList(file(".hoodie", true), file("part-0.parquet", false)))
+            .join());
+  }
+
+  @Test
+  void doesNotMatchWhenAbsent() {
+    assertFalse(
+        detector
+            .matches(ANY_PATH, Collections.singletonList(file("part-0.parquet", false)))
+            .join());
+  }
+
+  @Test
+  void doesNotMatchOnIcebergLayout() {
+    assertFalse(
+        detector
+            .matches(ANY_PATH, Arrays.asList(file("metadata", true), file("data", true)))
+            .join());
+  }
+
+  private static File file(String name, boolean dir) {
+    return File.builder().filename(name).isDirectory(dir).lastModifiedAt(Instant.EPOCH).build();
+  }
+}


### PR DESCRIPTION
## Summary

Sub-PR 1 of 2 splitting #189. Pure refactor — extracts the hardcoded `.hoodie/` check in `TableDiscoveryService` into a `TableFormatDetector` SPI with one implementation per format. Only `HudiTableFormatDetector` is registered today, so behavior is unchanged: every `Database` (including those with no `tableFormat` in YAML) routes through the Hudi detector.

## What changed

**New**
- `TableFormat` enum (`HUDI`, `ICEBERG`) with `@JsonProperty` aliases matching the protobuf enum names (`TABLE_FORMAT_HUDI`, `TABLE_FORMAT_ICEBERG`). `ICEBERG` is unused in this PR but lets the wire shape settle before the iceberg detector + uploader land.
- `TableFormatDetector` SPI interface — async `matches(path, listedFiles)` so future detectors can do follow-up listings without a refactor.
- `HudiTableFormatDetector` — same logic as the old `isHudiTableFolder` (`anyMatch(filename startsWith .hoodie)`), moved behind the SPI.
- `TestHudiTableFormatDetector` — unit coverage.

**Modified**
- `Database` — adds nullable `tableFormat` field. Null is interpreted as `HUDI` for backward compatibility with existing YAMLs.
- `TableDiscoveryService` — uses `Map<TableFormat, TableFormatDetector>` and picks the detector by `database.getTableFormat()` (null → HUDI). The detector map currently has only the HUDI entry.
- `TableDiscoveryServiceTest` — constructor signature update.

## Hudi safety

| Check | Status |
|---|---|
| Existing YAMLs (no `tableFormat`) still discover Hudi tables | ✓ — null → HUDI in `detectorFor` |
| `HudiTableFormatDetector.matches` is byte-for-byte the old `isHudiTableFolder` | ✓ |
| `TableMetadataUploaderService` (Hudi upload path) untouched | ✓ |
| Full `:lakeview:test` suite passes locally | ✓ |

## Out of scope (follow-up PR)

The iceberg-specific pieces from #189 are deferred:
- `IcebergTableFormatDetector` + `IcebergMetadataUploaderService`
- `Database.tableHints` + `TableHint`
- `Table.tableFormat`, `Table.metadataLocationHint`
- `TableDiscoveryAndUploadJob.dispatchUpload` routing
- `InitializeTableMetricsCheckpointRequest.tableFormat`
- `s3a://` in `OBJECT_STORAGE_URI_PATTERN`
- `docs/iceberg-support.md`

## Test plan

- [x] `./gradlew :lakeview:test` green locally (full suite)
- [x] `TableDiscoveryServiceTest` (existing) passes unchanged behavior
- [x] `TestHudiTableFormatDetector` covers detector contract + iceberg-shape negative case
- [x] CI green