### PR TITLE
[ENG-41614] Discover and upload Iceberg tables alongside Hudi

### DIFF
--- a/docs/iceberg-support.md
+++ b/docs/iceberg-support.md
@@ -1,0 +1,92 @@
+# Iceberg Table Support
+
+LakeView discovers and uploads metadata for Apache Iceberg tables alongside Hudi tables. For
+Iceberg, the extractor uploads the current `metadata.json` pointer file each iteration; the control
+plane parses the snapshot summary from it (cumulative `total-records`, `total-files-size`,
+`total-data-files`, per-snapshot deltas, and the `snapshot-log[]` history) and writes metrics to
+OpenSearch.
+
+## Table format detection
+
+Format detection is a pluggable SPI, `TableFormatDetector`, with one implementation per format:
+
+- `HudiTableFormatDetector` — a directory is a Hudi table root if it contains a `.hoodie/` folder.
+- `IcebergTableFormatDetector` — a directory is an Iceberg table root if it contains a `metadata/`
+  sub-directory **and** that sub-directory holds at least one `*.metadata.json` pointer file. The
+  pointer-file check separates a real Iceberg table from any folder that merely has a sub-directory
+  named `metadata` (Spark checkpoint dirs, docs folders, etc.). This costs one extra `LIST` per
+  candidate directory during discovery — not per upload cycle.
+
+Detectors are **not raced** against each other. Each `Database` in the parser YAML declares its
+`tableFormat`, and `TableDiscoveryService` selects the single matching detector for every directory
+under that database's base paths.
+
+### Declaring the format in parser YAML
+
+```yaml
+parserConfig:
+  - lake: my_lake
+    databases:
+      - name: my_iceberg_db
+        tableFormat: ICEBERG        # absent / null => HUDI (back-compat)
+        basePaths:
+          - s3://bucket/warehouse/my_iceberg_db/
+```
+
+A mixed-format warehouse should be split into separate `Database` entries, one per format.
+
+## Selecting the current `metadata.json`
+
+`IcebergMetadataUploaderService` resolves the current pointer through three paths, in order of
+preference:
+
+1. **`metadataLocationHint`** — the URI of the current `metadata.json` supplied by the control plane
+   in the parser YAML's `tableHints` (e.g. from AWS Glue's `metadata_location` parameter). When
+   present, the extractor PUTs the file directly and skips the per-cycle `metadata/` listing.
+   *Hints only apply to base paths pinned with an explicit `#tableId`; auto-discovered tables always
+   fall back to listing.*
+2. **`metadata/version-hint.text`** — for Hadoop-catalog tables, its integer content names the
+   current `v{N}.metadata.json` unambiguously.
+3. **Numeric-aware filename comparison** (last resort) — the leading integer in the filename (after
+   an optional `v` prefix) is the version number. Works for both `v{N}.metadata.json` (Hadoop) and
+   `00000-<uuid>.metadata.json` (Hive/Glue/Spark). **Caveat:** the highest-versioned file is not
+   guaranteed to be the catalog's committed pointer — a failed or concurrent write can leave an
+   orphan with a higher version. This is best-effort; paths 1 and 2 are authoritative and preferred
+   for exactly that reason.
+
+The checkpoint tracks the last-uploaded filename; if it hasn't advanced since the last run, the
+iteration is a no-op.
+
+`s3a://` URIs (the Hadoop scheme that Glue/Onehouse-agent `metadata_location` values use) are
+accepted by the storage URI parser in addition to `s3://`.
+
+## Upload orchestration
+
+`TableDiscoveryAndUploadJob.dispatchUpload` partitions discovered tables by format and runs the Hudi
+(`TableMetadataUploaderService`) and Iceberg (`IcebergMetadataUploaderService`) uploaders
+concurrently. A `null` table format is treated as `HUDI`. `IcebergMetadataUploaderService` is a
+sibling of the Hudi uploader rather than a subclass — Hudi's active/archived timeline distinction,
+`hoodie.properties` bootstrap, and LSM manifest plumbing don't apply to Iceberg — but it reuses the
+shared `OnehouseApiClient`, `PresignedUrlFileUploader`, `AsyncStorageClient`, and `StorageUtils`.
+
+On the init RPC (`InitializeTableMetricsCheckpoint`), Iceberg tables send `tableFormat=ICEBERG` and
+a placeholder `tableType=COPY_ON_WRITE` (the server discriminates on `tableFormat` first; `tableType`
+is meaningless for Iceberg but stays non-null to preserve the wire contract).
+
+## Deployment ordering
+
+⚠️ This feature spans three repositories and **must be rolled out in order**:
+
+1. **idls** — adds the `TableFormat` proto enum / `TableMetricsCheckpoint` field
+   ([idls PR #1939](https://github.com/onehouseinc/idls/pull/1939)).
+2. **gateway-controller** — adds `IcebergCommitMetadataParser` to parse the uploaded `metadata.json`
+   and emit metrics to OpenSearch.
+3. **LakeView** (this repo) — discovers Iceberg tables and uploads `metadata.json`.
+
+If LakeView ships **before** the server understands `tableFormat`, the server-side protobuf JSON
+parser drops the unknown enum value and persists the proto enum-zero default
+(`TABLE_FORMAT_INVALID`), routing Iceberg uploads through the Hudi back-compat fallback — i.e. the
+control plane tries to parse an Iceberg `metadata.json` as a Hudi commit. **Before deploying
+LakeView, confirm the running control plane tolerates `tableFormat=ICEBERG` cleanly** (errors or
+ignores rather than corrupting the checkpoint), and deploy the idls + gateway-controller changes
+first.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ This directory holds conceptual / architectural / operational documentation for 
 
 - [overview.md](overview.md) — what this repo does and where it fits in the OneHouse stack
 - [getting-started.md](getting-started.md) — local development setup
+- [iceberg-support.md](iceberg-support.md) — Iceberg table discovery, metadata.json selection, and deploy ordering
 
 ## Adding a doc
 

--- a/lakeview-sync-tool/src/main/java/ai/onehouse/lakeview/sync/LakeviewSyncTool.java
+++ b/lakeview-sync-tool/src/main/java/ai/onehouse/lakeview/sync/LakeviewSyncTool.java
@@ -15,6 +15,8 @@ import ai.onehouse.config.models.configv1.ParserConfig;
 import ai.onehouse.metadata_extractor.ActiveTimelineInstantBatcher;
 import ai.onehouse.metadata_extractor.HoodiePropertiesReader;
 import ai.onehouse.metadata_extractor.HudiTableFormatDetector;
+import ai.onehouse.metadata_extractor.IcebergMetadataUploaderService;
+import ai.onehouse.metadata_extractor.IcebergTableFormatDetector;
 import ai.onehouse.metadata_extractor.LSMTimelineManifestReader;
 import ai.onehouse.metadata_extractor.TableDiscoveryAndUploadJob;
 import ai.onehouse.metadata_extractor.TableDiscoveryService;
@@ -254,7 +256,9 @@ public class LakeviewSyncTool extends HoodieSyncTool implements AutoCloseable {
         configProvider);
 
     TableDiscoveryService tableDiscoveryService = new TableDiscoveryService(asyncStorageClient, storageUtils,
-            configProvider, executorService, lakeViewExtractorMetrics, new HudiTableFormatDetector());
+            configProvider, executorService, lakeViewExtractorMetrics,
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector(asyncStorageClient, storageUtils));
     HoodiePropertiesReader hoodiePropertiesReader = new HoodiePropertiesReader(asyncStorageClient,
         lakeViewExtractorMetrics);
     OnehouseApiClient onehouseApiClient = new OnehouseApiClient(asyncHttpClientWithRetry, config,
@@ -268,8 +272,11 @@ public class LakeviewSyncTool extends HoodieSyncTool implements AutoCloseable {
         lakeViewExtractorMetrics, config, lsmTimelineManifestReader);
     TableMetadataUploaderService tableMetadataUploaderService = new TableMetadataUploaderService(hoodiePropertiesReader,
         onehouseApiClient, timelineCommitInstantsUploader, lakeViewExtractorMetrics, executorService);
+    IcebergMetadataUploaderService icebergMetadataUploaderService = new IcebergMetadataUploaderService(
+        asyncStorageClient, onehouseApiClient, presignedUrlFileUploader, storageUtils, lakeViewExtractorMetrics);
 
-    return new TableDiscoveryAndUploadJob(tableDiscoveryService, tableMetadataUploaderService, lakeViewExtractorMetrics, asyncStorageClient);
+    return new TableDiscoveryAndUploadJob(tableDiscoveryService, tableMetadataUploaderService,
+        icebergMetadataUploaderService, lakeViewExtractorMetrics, asyncStorageClient);
   }
 
   private AsyncStorageClient getAsyncStorageClient(@Nonnull Config config, @Nonnull ExecutorService executorService,

--- a/lakeview/src/main/java/ai/onehouse/api/models/request/InitializeTableMetricsCheckpointRequest.java
+++ b/lakeview/src/main/java/ai/onehouse/api/models/request/InitializeTableMetricsCheckpointRequest.java
@@ -21,7 +21,13 @@ public class InitializeTableMetricsCheckpointRequest {
   public static class InitializeSingleTableMetricsCheckpointRequest {
     @NonNull String tableId;
     @NonNull String tableName;
+    // For Hudi: source of truth for COW vs MOR. For non-Hudi formats it is a meaningless
+    // placeholder; the server discriminates on tableFormat first. Kept non-null to preserve
+    // the existing wire contract; defaults to COPY_ON_WRITE for Iceberg tables.
     @NonNull TableType tableType;
+    // Physical table format. Absent is interpreted by the server as HUDI for backward compat
+    // with extractors that haven't been updated.
+    @Nullable TableFormat tableFormat;
     String lakeName;
     String databaseName;
     String tableBasePath;

--- a/lakeview/src/main/java/ai/onehouse/api/models/request/InitializeTableMetricsCheckpointRequest.java
+++ b/lakeview/src/main/java/ai/onehouse/api/models/request/InitializeTableMetricsCheckpointRequest.java
@@ -21,12 +21,16 @@ public class InitializeTableMetricsCheckpointRequest {
   public static class InitializeSingleTableMetricsCheckpointRequest {
     @NonNull String tableId;
     @NonNull String tableName;
-    // For Hudi: source of truth for COW vs MOR. For non-Hudi formats it is a meaningless
-    // placeholder; the server discriminates on tableFormat first. Kept non-null to preserve
-    // the existing wire contract; defaults to COPY_ON_WRITE for Iceberg tables.
+    /*
+     * For Hudi: source of truth for COW vs MOR. For non-Hudi formats it is a meaningless
+     * placeholder; the server discriminates on tableFormat first. Kept non-null to preserve
+     * the existing wire contract; defaults to COPY_ON_WRITE for Iceberg tables.
+     */
     @NonNull TableType tableType;
-    // Physical table format. Absent is interpreted by the server as HUDI for backward compat
-    // with extractors that haven't been updated.
+    /*
+     * Physical table format. Absent is interpreted by the server as HUDI for backward compat
+     * with extractors that haven't been updated.
+     */
     @Nullable TableFormat tableFormat;
     String lakeName;
     String databaseName;

--- a/lakeview/src/main/java/ai/onehouse/config/models/configv1/Database.java
+++ b/lakeview/src/main/java/ai/onehouse/config/models/configv1/Database.java
@@ -2,6 +2,7 @@ package ai.onehouse.config.models.configv1;
 
 import ai.onehouse.api.models.request.TableFormat;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.NonNull;
@@ -16,9 +17,17 @@ public class Database {
   @NonNull List<String> basePaths;
   /**
    * Physical table format of the tables under {@link #basePaths}. Null is interpreted as {@link
-   * TableFormat#HUDI} for backward compatibility with YAMLs written before format-aware
-   * discovery existed. Customers with a mixed-format warehouse should split into separate {@link
-   * Database} entries, one per format.
+   * TableFormat#HUDI} for backward compatibility with YAMLs written before Iceberg support
+   * existed. Customers with a mixed-format warehouse should split into separate {@link Database}
+   * entries, one per format.
    */
   @Nullable TableFormat tableFormat;
+  /**
+   * Optional per-table hints keyed on the tableId encoded in {@link #basePaths} (the segment after
+   * {@code #}). The control plane populates this for tables it has richer information about
+   * (e.g. Iceberg tables discovered via AWS Glue, where the catalog already knows the current
+   * {@code metadata.json} URI). Missing entries / missing map are normal — older YAML versions
+   * predate this field, and tables without hints fall back to plain discovery.
+   */
+  @Nullable Map<String, TableHint> tableHints;
 }

--- a/lakeview/src/main/java/ai/onehouse/config/models/configv1/TableHint.java
+++ b/lakeview/src/main/java/ai/onehouse/config/models/configv1/TableHint.java
@@ -1,0 +1,24 @@
+package ai.onehouse.config.models.configv1;
+
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * Optional per-table hints supplied by the control plane in the parser YAML, keyed on tableId in
+ * {@link Database#getTableHints()}. Hints are forward-compatible: older LakeView versions that
+ * don't know about a field deserialize the rest fine; new fields default to null.
+ */
+@Builder
+@Value
+@Jacksonized
+public class TableHint {
+  /**
+   * For Iceberg tables registered in an external catalog (e.g. AWS Glue), the URI of the current
+   * {@code metadata.json} that the catalog points at. When present, the extractor can PUT this
+   * file directly instead of listing the {@code metadata/} folder to find the latest. Empty /
+   * null means "no hint — fall back to listing".
+   */
+  @Nullable String metadataLocationHint;
+}

--- a/lakeview/src/main/java/ai/onehouse/constants/MetadataExtractorConstants.java
+++ b/lakeview/src/main/java/ai/onehouse/constants/MetadataExtractorConstants.java
@@ -14,6 +14,10 @@ public class MetadataExtractorConstants {
 
   public static final String HOODIE_FOLDER_NAME = ".hoodie";
   public static final String ARCHIVED_FOLDER_NAME = "archived";
+  public static final String ICEBERG_METADATA_FOLDER_NAME = "metadata";
+  public static final String ICEBERG_METADATA_FILE_SUFFIX = ".metadata.json";
+  public static final String ICEBERG_VERSION_HINT_FILENAME = "version-hint.text";
+  public static final String ICEBERG_HADOOP_METADATA_FILE_PREFIX = "v";
   public static final String HOODIE_PROPERTIES_FILE = "hoodie.properties";
   public static final String HOODIE_TABLE_NAME_KEY = "hoodie.table.name";
   public static final String HOODIE_TABLE_TYPE_KEY = "hoodie.table.type";

--- a/lakeview/src/main/java/ai/onehouse/constants/StorageConstants.java
+++ b/lakeview/src/main/java/ai/onehouse/constants/StorageConstants.java
@@ -7,13 +7,15 @@ public class StorageConstants {
 
   /*
   * typical s3 path: "s3://bucket-name/path/to/object"
+  * hadoop-style s3 path: "s3a://bucket-name/path/to/object" (e.g. iceberg metadata_location entries
+  *   stamped by Glue/Onehouse agent — see gateway-controller commit 0761ef368d)
   * gcs path format: "gs://bucket/path/to/file"
   * azure blob format: "https://account.blob.core.windows.net/container/path/to/blob"
   * azure adls gen2 format: "https://account.dfs.core.windows.net/container/path/to/file"
   * azure adls gen2 abfss format: "abfss://container@account.dfs.core.windows.net/path/to/file"
   */
   public static final Pattern OBJECT_STORAGE_URI_PATTERN =
-      Pattern.compile("^(?:(s3://|gs://|abfss://)|https://[^.]+\\.(?:blob|dfs)\\.core\\.windows\\.net/)([^/@]+)(?:@[^/]+)?(/.*)?$");
+      Pattern.compile("^(?:(s3a?://|gs://|abfss://)|https://[^.]+\\.(?:blob|dfs)\\.core\\.windows\\.net/)([^/@]+)(?:@[^/]+)?(/.*)?$");
 
   // https://cloud.google.com/compute/docs/naming-resources#resource-name-format
   public static final String GCP_RESOURCE_NAME_FORMAT = "^[a-z]([-a-z0-9]*[a-z0-9])$";

--- a/lakeview/src/main/java/ai/onehouse/constants/StorageConstants.java
+++ b/lakeview/src/main/java/ai/onehouse/constants/StorageConstants.java
@@ -8,7 +8,7 @@ public class StorageConstants {
   /*
   * typical s3 path: "s3://bucket-name/path/to/object"
   * hadoop-style s3 path: "s3a://bucket-name/path/to/object" (e.g. iceberg metadata_location entries
-  *   stamped by Glue/Onehouse agent — see gateway-controller commit 0761ef368d)
+  *   stamped by Glue/Onehouse agent)
   * gcs path format: "gs://bucket/path/to/file"
   * azure blob format: "https://account.blob.core.windows.net/container/path/to/blob"
   * azure adls gen2 format: "https://account.dfs.core.windows.net/container/path/to/file"

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
@@ -1,0 +1,475 @@
+package ai.onehouse.metadata_extractor;
+
+import static ai.onehouse.constants.MetadataExtractorConstants.DEFAULT_FILE_UPLOAD_STREAM_BATCH_SIZE;
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_HADOOP_METADATA_FILE_PREFIX;
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FILE_SUFFIX;
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FOLDER_NAME;
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_VERSION_HINT_FILENAME;
+import static ai.onehouse.constants.MetadataExtractorConstants.INITIAL_CHECKPOINT;
+import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataExtractorFailureReason;
+
+import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
+import ai.onehouse.api.OnehouseApiClient;
+import ai.onehouse.api.models.request.CommitTimelineType;
+import ai.onehouse.api.models.request.GenerateCommitMetadataUploadUrlRequest;
+import ai.onehouse.api.models.request.InitializeTableMetricsCheckpointRequest;
+import ai.onehouse.api.models.request.InitializeTableMetricsCheckpointRequest.InitializeSingleTableMetricsCheckpointRequest;
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.api.models.request.TableType;
+import ai.onehouse.api.models.request.UploadedFile;
+import ai.onehouse.api.models.request.UpsertTableMetricsCheckpointRequest;
+import ai.onehouse.api.models.response.GetTableMetricsCheckpointResponse;
+import ai.onehouse.constants.MetricsConstants;
+import ai.onehouse.metadata_extractor.models.Checkpoint;
+import ai.onehouse.metadata_extractor.models.Table;
+import ai.onehouse.metrics.LakeViewExtractorMetrics;
+import ai.onehouse.storage.AsyncStorageClient;
+import ai.onehouse.storage.PresignedUrlFileUploader;
+import ai.onehouse.storage.StorageUtils;
+import ai.onehouse.storage.models.File;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Discovers and uploads Iceberg table metadata pointer files ({@code metadata/*.metadata.json}).
+ *
+ * <p>Iceberg's snapshot-summary contract means a single {@code metadata.json} contains all of:
+ * cumulative {@code total-records}, {@code total-files-size}, {@code total-data-files},
+ * per-snapshot deltas, and {@code snapshot-log[]} history. We therefore upload exactly one file
+ * per iteration — the latest {@code metadata.json}. The control plane parses snapshot summaries
+ * from it and writes metrics to OpenSearch.
+ *
+ * <p>Parallel to {@link TableMetadataUploaderService} (the Hudi orchestrator) rather than a
+ * subclass: Hudi's active/archived timeline distinction, hoodie.properties bootstrap, and LSM
+ * manifest plumbing don't apply, so a separate service is clearer than a branching megaclass.
+ * Shared primitives ({@link OnehouseApiClient}, {@link PresignedUrlFileUploader}, {@link
+ * AsyncStorageClient}) are reused.
+ *
+ * <p>The {@code thenComposeAsync}/{@code thenApply} stages below intentionally run on the default
+ * fork-join pool: they are non-blocking glue around the already-async storage and API clients, so
+ * a dedicated executor would buy nothing.
+ *
+ * <p><b>Selecting the current pointer.</b> Three paths, in order of preference:
+ * <ol>
+ *   <li>{@link Table#getMetadataLocationHint()} from the parser YAML (catalog-driven).</li>
+ *   <li>{@code metadata/version-hint.text} for Hadoop-catalog tables — its integer content names
+ *       the current {@code v{N}.metadata.json} unambiguously.</li>
+ *   <li>Numeric-aware filename comparison as a last resort. The leading integer in the filename
+ *       (after an optional {@code v} prefix) is treated as the version number. Works for both
+ *       {@code v{N}.metadata.json} (Hadoop) and {@code 00000-<uuid>.metadata.json}
+ *       (Hive/Glue/Spark) without depending on zero-padding.</li>
+ * </ol>
+ */
+@Slf4j
+public class IcebergMetadataUploaderService {
+  private final AsyncStorageClient asyncStorageClient;
+  private final OnehouseApiClient onehouseApiClient;
+  private final PresignedUrlFileUploader presignedUrlFileUploader;
+  private final StorageUtils storageUtils;
+  private final LakeViewExtractorMetrics metrics;
+  private final ObjectMapper mapper;
+
+  @Inject
+  public IcebergMetadataUploaderService(
+      @Nonnull @TableDiscoveryObjectStorageAsyncClient AsyncStorageClient asyncStorageClient,
+      @Nonnull OnehouseApiClient onehouseApiClient,
+      @Nonnull PresignedUrlFileUploader presignedUrlFileUploader,
+      @Nonnull StorageUtils storageUtils,
+      @Nonnull LakeViewExtractorMetrics metrics) {
+    this.asyncStorageClient = asyncStorageClient;
+    this.onehouseApiClient = onehouseApiClient;
+    this.presignedUrlFileUploader = presignedUrlFileUploader;
+    this.storageUtils = storageUtils;
+    this.metrics = metrics;
+    this.mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+  }
+
+  /**
+   * Uploads the latest metadata.json for each Iceberg table whose pointer file has advanced since
+   * the last checkpoint. Returns true only if every table either succeeded or was already
+   * up-to-date.
+   */
+  public CompletableFuture<Boolean> uploadInstantsInTables(Set<Table> tables) {
+    if (tables.isEmpty()) {
+      return CompletableFuture.completedFuture(true);
+    }
+    log.info("Uploading Iceberg metadata for {} table(s)", tables.size());
+    List<CompletableFuture<Boolean>> perTable =
+        tables.stream().map(this::processTable).collect(Collectors.toList());
+    return CompletableFuture.allOf(perTable.toArray(new CompletableFuture[0]))
+        .thenApply(
+            ignored -> perTable.stream().map(CompletableFuture::join).allMatch(Boolean.TRUE::equals));
+  }
+
+  private CompletableFuture<Boolean> processTable(Table table) {
+    return onehouseApiClient
+        .getTableMetricsCheckpoints(Collections.singletonList(table.getTableId()))
+        .thenComposeAsync(
+            response -> {
+              if (response.isFailure()) {
+                log.error(
+                    "Failed to fetch checkpoint for Iceberg table {} (status {}): {}",
+                    table.getTableId(),
+                    response.getStatusCode(),
+                    response.getCause());
+                metrics.incrementTableMetadataProcessingFailureCounter(
+                    MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR,
+                    "Failed to fetch checkpoint for Iceberg table");
+                return CompletableFuture.completedFuture(false);
+              }
+              Optional<Checkpoint> existing = parseCheckpoint(response, table.getTableId());
+              if (existing.isPresent()) {
+                return uploadIfNewMetadataJson(table, existing.get());
+              }
+              return initialiseTable(table)
+                  .thenComposeAsync(
+                      initOk -> {
+                        if (Boolean.FALSE.equals(initOk)) {
+                          return CompletableFuture.completedFuture(false);
+                        }
+                        return uploadIfNewMetadataJson(table, INITIAL_CHECKPOINT);
+                      });
+            })
+        .exceptionally(
+            e -> {
+              log.error("Exception processing Iceberg table {}", table.getTableId(), e);
+              metrics.incrementTableMetadataProcessingFailureCounter(
+                  getMetadataExtractorFailureReason(
+                      e, MetricsConstants.MetadataUploadFailureReasons.UNKNOWN),
+                  String.format("Iceberg upload exception: %s", e.getMessage()));
+              return false;
+            });
+  }
+
+  private Optional<Checkpoint> parseCheckpoint(
+      GetTableMetricsCheckpointResponse response, String tableId) {
+    return response.getCheckpoints().stream()
+        .filter(c -> tableId.equals(c.getTableId()))
+        .findFirst()
+        .map(GetTableMetricsCheckpointResponse.TableMetadataCheckpoint::getCheckpoint)
+        .filter(StringUtils::isNotBlank)
+        .map(
+            json -> {
+              try {
+                return mapper.readValue(json, Checkpoint.class);
+              } catch (JsonProcessingException e) {
+                log.error("Malformed checkpoint JSON for Iceberg table {}; treating as missing", tableId, e);
+                return null;
+              }
+            });
+  }
+
+  private CompletableFuture<Boolean> initialiseTable(Table table) {
+    String tableName = deriveTableName(table.getAbsoluteTableUri());
+    InitializeSingleTableMetricsCheckpointRequest single =
+        InitializeSingleTableMetricsCheckpointRequest.builder()
+            .tableId(table.getTableId())
+            .tableName(tableName)
+            // COW is a meaningless placeholder for Iceberg; server discriminates on tableFormat.
+            .tableType(TableType.COPY_ON_WRITE)
+            .tableFormat(TableFormat.ICEBERG)
+            .lakeName(table.getLakeName())
+            .databaseName(table.getDatabaseName())
+            .tableBasePath(table.getAbsoluteTableUri())
+            .build();
+    return onehouseApiClient
+        .initializeTableMetricsCheckpoint(
+            InitializeTableMetricsCheckpointRequest.builder()
+                .tables(Collections.singletonList(single))
+                .build())
+        .thenApply(
+            initResponse -> {
+              if (initResponse.isFailure()) {
+                log.error(
+                    "Failed to initialise Iceberg table {} (status {}): {}",
+                    table.getTableId(),
+                    initResponse.getStatusCode(),
+                    initResponse.getCause());
+                metrics.incrementTableMetadataProcessingFailureCounter(
+                    MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR,
+                    "Failed to initialise Iceberg table");
+                return false;
+              }
+              return true;
+            });
+  }
+
+  private CompletableFuture<Boolean> uploadIfNewMetadataJson(Table table, Checkpoint checkpoint) {
+    // Fast path: control plane provided the current metadata.json URI (e.g. from AWS Glue's
+    // metadata_location parameter). Skip the per-cycle LIST and PUT the file directly.
+    if (StringUtils.isNotBlank(table.getMetadataLocationHint())) {
+      String hint = table.getMetadataLocationHint();
+      String filename = lastPathSegment(hint);
+      if (filename.equals(checkpoint.getLastUploadedFile())) {
+        log.debug(
+            "Iceberg table {} already up-to-date at {} (from hint)",
+            table.getTableId(),
+            filename);
+        return CompletableFuture.completedFuture(true);
+      }
+      File synthetic =
+          File.builder()
+              .filename(filename)
+              .isDirectory(false)
+              // Hint doesn't carry lastModifiedAt; use now() since the consumer treats this as
+              // advisory and discriminates by checkpoint batchId for ordering.
+              .lastModifiedAt(Instant.now())
+              .build();
+      return uploadAndAdvanceCheckpoint(table, hint, synthetic, checkpoint);
+    }
+
+    // Fallback path: list metadata/, prefer version-hint.text, else numeric-aware sort.
+    String metadataDirUri =
+        storageUtils.constructFileUri(table.getAbsoluteTableUri(), ICEBERG_METADATA_FOLDER_NAME);
+    return asyncStorageClient
+        .listAllFilesInDir(metadataDirUri)
+        .thenComposeAsync(
+            files ->
+                resolveLatestMetadataJson(metadataDirUri, files)
+                    .thenComposeAsync(
+                        latestOpt -> {
+                          if (!latestOpt.isPresent()) {
+                            log.error(
+                                "Iceberg table {} has no *.metadata.json under {}",
+                                table.getTableId(),
+                                metadataDirUri);
+                            metrics.incrementTableMetadataProcessingFailureCounter(
+                                MetricsConstants.MetadataUploadFailureReasons.NO_SUCH_KEY,
+                                "Iceberg table missing metadata.json files");
+                            return CompletableFuture.completedFuture(false);
+                          }
+                          File latest = latestOpt.get();
+                          if (latest.getFilename().equals(checkpoint.getLastUploadedFile())) {
+                            log.debug(
+                                "Iceberg table {} already up-to-date at {}",
+                                table.getTableId(),
+                                latest.getFilename());
+                            return CompletableFuture.completedFuture(true);
+                          }
+                          String fileUri =
+                              storageUtils.constructFileUri(metadataDirUri, latest.getFilename());
+                          return uploadAndAdvanceCheckpoint(table, fileUri, latest, checkpoint);
+                        }));
+  }
+
+  /**
+   * Resolves the current {@code metadata.json} given a listing of {@code metadata/}. Reads
+   * {@code version-hint.text} when present and falls back to numeric-aware filename comparison
+   * otherwise.
+   */
+  private CompletableFuture<Optional<File>> resolveLatestMetadataJson(
+      String metadataDirUri, List<File> files) {
+    Optional<File> versionHintFile =
+        files.stream()
+            .filter(f -> !f.isDirectory() && ICEBERG_VERSION_HINT_FILENAME.equals(f.getFilename()))
+            .findFirst();
+    if (!versionHintFile.isPresent()) {
+      return CompletableFuture.completedFuture(pickLatestMetadataJson(files));
+    }
+    String hintUri = storageUtils.constructFileUri(metadataDirUri, ICEBERG_VERSION_HINT_FILENAME);
+    return asyncStorageClient
+        .readFileAsBytes(hintUri)
+        .thenApply(
+            bytes -> {
+              Optional<File> fromHint = resolveFromVersionHint(bytes, files);
+              if (fromHint.isPresent()) {
+                return fromHint;
+              }
+              log.warn(
+                  "version-hint.text at {} did not point at an existing metadata.json; falling back to numeric sort",
+                  hintUri);
+              return pickLatestMetadataJson(files);
+            })
+        .exceptionally(
+            ex -> {
+              log.warn(
+                  "Failed to read version-hint.text at {}; falling back to numeric sort",
+                  hintUri,
+                  ex);
+              return pickLatestMetadataJson(files);
+            });
+  }
+
+  static Optional<File> resolveFromVersionHint(byte[] versionHintBytes, List<File> files) {
+    String content = new String(versionHintBytes, StandardCharsets.UTF_8).trim();
+    long version;
+    try {
+      version = Long.parseLong(content);
+    } catch (NumberFormatException e) {
+      log.warn("version-hint.text contained non-integer content: '{}'", content);
+      return Optional.empty();
+    }
+    String target = ICEBERG_HADOOP_METADATA_FILE_PREFIX + version + ICEBERG_METADATA_FILE_SUFFIX;
+    return files.stream()
+        .filter(f -> !f.isDirectory() && target.equals(f.getFilename()))
+        .findFirst();
+  }
+
+  private CompletableFuture<Boolean> uploadAndAdvanceCheckpoint(
+      Table table, String fileUri, File metadataJson, Checkpoint priorCheckpoint) {
+    return onehouseApiClient
+        .generateCommitMetadataUploadUrl(
+            GenerateCommitMetadataUploadUrlRequest.builder()
+                .tableId(table.getTableId())
+                .commitInstants(Collections.singletonList(metadataJson.getFilename()))
+                // ACTIVE is a placeholder; Iceberg has no archived/active distinction.
+                .commitTimelineType(CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE)
+                .build())
+        .thenComposeAsync(
+            urlResponse -> {
+              if (urlResponse.isFailure() || urlResponse.getUploadUrls().isEmpty()) {
+                log.error(
+                    "Failed to obtain presigned URL for {} (status {}): {}",
+                    metadataJson.getFilename(),
+                    urlResponse.getStatusCode(),
+                    urlResponse.getCause());
+                metrics.incrementTableMetadataProcessingFailureCounter(
+                    MetricsConstants.MetadataUploadFailureReasons.PRESIGNED_URL_UPLOAD_FAILURE,
+                    "Failed to obtain presigned URL for Iceberg metadata.json");
+                return CompletableFuture.completedFuture(false);
+              }
+              String presigned = urlResponse.getUploadUrls().get(0);
+              return presignedUrlFileUploader
+                  .uploadFileToPresignedUrl(presigned, fileUri, DEFAULT_FILE_UPLOAD_STREAM_BATCH_SIZE)
+                  .thenComposeAsync(
+                      ignored -> {
+                        metrics.incrementMetadataUploadSuccessCounter();
+                        return advanceCheckpoint(table, metadataJson, priorCheckpoint);
+                      });
+            });
+  }
+
+  private CompletableFuture<Boolean> advanceCheckpoint(
+      Table table, File metadataJson, Checkpoint priorCheckpoint) {
+    Checkpoint next =
+        priorCheckpoint
+            .toBuilder()
+            .batchId(priorCheckpoint.getBatchId() + 1)
+            .checkpointTimestamp(Instant.now())
+            .lastUploadedFile(metadataJson.getFilename())
+            // Iceberg has no archived/active distinction; mark archived processed so consumers
+            // that interpret the legacy field for ordering don't loop.
+            .archivedCommitsProcessed(true)
+            .build();
+    String checkpointJson;
+    try {
+      checkpointJson = mapper.writeValueAsString(next);
+    } catch (JsonProcessingException e) {
+      log.error("Failed to serialise Iceberg checkpoint for table {}", table.getTableId(), e);
+      return CompletableFuture.completedFuture(false);
+    }
+    UpsertTableMetricsCheckpointRequest request =
+        UpsertTableMetricsCheckpointRequest.builder()
+            .tableId(table.getTableId())
+            .checkpoint(checkpointJson)
+            .filesUploaded(Collections.singletonList(metadataJson.getFilename()))
+            .uploadedFiles(
+                Collections.singletonList(
+                    UploadedFile.builder()
+                        .name(metadataJson.getFilename())
+                        .lastModifiedAt(metadataJson.getLastModifiedAt().toEpochMilli())
+                        .build()))
+            .commitTimelineType(CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE)
+            .build();
+    return onehouseApiClient
+        .upsertTableMetricsCheckpoint(request)
+        .thenApply(
+            upsert -> {
+              if (upsert.isFailure()) {
+                log.error(
+                    "Failed to upsert checkpoint for Iceberg table {} (status {}): {}",
+                    table.getTableId(),
+                    upsert.getStatusCode(),
+                    upsert.getCause());
+                metrics.incrementTableMetadataProcessingFailureCounter(
+                    MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR,
+                    "Failed to upsert checkpoint for Iceberg table");
+                return false;
+              }
+              return true;
+            });
+  }
+
+  /**
+   * Picks the latest {@code *.metadata.json} from a {@code metadata/} listing using numeric-aware
+   * comparison. The leading integer in the filename (after an optional {@code v} prefix) is the
+   * version number; ties fall back to lexicographic order on the full filename so the result is
+   * deterministic.
+   *
+   * <p>Examples:
+   * <ul>
+   *   <li>{@code v1.metadata.json}, {@code v10.metadata.json}, {@code v2.metadata.json} →
+   *       {@code v10.metadata.json}</li>
+   *   <li>{@code 00001-a.metadata.json}, {@code 00010-b.metadata.json} →
+   *       {@code 00010-b.metadata.json}</li>
+   * </ul>
+   *
+   * <p><b>Caveat:</b> the highest-versioned file is not guaranteed to be the catalog's committed
+   * pointer — a failed or concurrent write can leave an orphan {@code metadata.json} with a higher
+   * version. This is a best-effort last resort; the {@code metadataLocationHint} and {@code
+   * version-hint.text} paths are authoritative and preferred precisely for that reason.
+   */
+  static Optional<File> pickLatestMetadataJson(List<File> files) {
+    Comparator<File> byVersionThenName =
+        Comparator.<File>comparingLong(f -> extractVersionNumber(f.getFilename()))
+            .thenComparing(File::getFilename);
+    return files.stream()
+        .filter(f -> !f.isDirectory())
+        .filter(f -> f.getFilename().endsWith(ICEBERG_METADATA_FILE_SUFFIX))
+        .max(byVersionThenName);
+  }
+
+  /**
+   * Extracts the leading integer "version number" from an Iceberg metadata-json filename. Returns
+   * {@code -1} when no integer prefix is present (the file still participates in ordering — it
+   * just loses any tiebreak with numerically-named siblings).
+   */
+  static long extractVersionNumber(String filename) {
+    String base =
+        filename.endsWith(ICEBERG_METADATA_FILE_SUFFIX)
+            ? filename.substring(0, filename.length() - ICEBERG_METADATA_FILE_SUFFIX.length())
+            : filename;
+    int i = 0;
+    if (i < base.length() && base.charAt(i) == 'v') {
+      i++;
+    }
+    int start = i;
+    while (i < base.length() && Character.isDigit(base.charAt(i))) {
+      i++;
+    }
+    if (i == start) {
+      return -1L;
+    }
+    try {
+      return Long.parseLong(base.substring(start, i));
+    } catch (NumberFormatException e) {
+      return -1L;
+    }
+  }
+
+  static String lastPathSegment(String uri) {
+    int idx = uri.lastIndexOf('/');
+    return idx < 0 ? uri : uri.substring(idx + 1);
+  }
+
+  private static String deriveTableName(String basePathUri) {
+    String trimmed = basePathUri.endsWith("/") ? basePathUri.substring(0, basePathUri.length() - 1) : basePathUri;
+    int idx = trimmed.lastIndexOf('/');
+    return idx < 0 ? trimmed : trimmed.substring(idx + 1);
+  }
+}

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergMetadataUploaderService.java
@@ -210,8 +210,10 @@ public class IcebergMetadataUploaderService {
   }
 
   private CompletableFuture<Boolean> uploadIfNewMetadataJson(Table table, Checkpoint checkpoint) {
-    // Fast path: control plane provided the current metadata.json URI (e.g. from AWS Glue's
-    // metadata_location parameter). Skip the per-cycle LIST and PUT the file directly.
+    /*
+     * Fast path: control plane provided the current metadata.json URI (e.g. from AWS Glue's
+     * metadata_location parameter). Skip the per-cycle LIST and PUT the file directly.
+     */
     if (StringUtils.isNotBlank(table.getMetadataLocationHint())) {
       String hint = table.getMetadataLocationHint();
       String filename = lastPathSegment(hint);
@@ -226,8 +228,10 @@ public class IcebergMetadataUploaderService {
           File.builder()
               .filename(filename)
               .isDirectory(false)
-              // Hint doesn't carry lastModifiedAt; use now() since the consumer treats this as
-              // advisory and discriminates by checkpoint batchId for ordering.
+              /*
+               * Hint doesn't carry lastModifiedAt; use now() since the consumer treats this as
+               * advisory and discriminates by checkpoint batchId for ordering.
+               */
               .lastModifiedAt(Instant.now())
               .build();
       return uploadAndAdvanceCheckpoint(table, hint, synthetic, checkpoint);
@@ -362,8 +366,10 @@ public class IcebergMetadataUploaderService {
             .batchId(priorCheckpoint.getBatchId() + 1)
             .checkpointTimestamp(Instant.now())
             .lastUploadedFile(metadataJson.getFilename())
-            // Iceberg has no archived/active distinction; mark archived processed so consumers
-            // that interpret the legacy field for ordering don't loop.
+            /*
+             * Iceberg has no archived/active distinction; mark archived processed so consumers
+             * that interpret the legacy field for ordering don't loop.
+             */
             .archivedCommitsProcessed(true)
             .build();
     String checkpointJson;

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergTableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergTableFormatDetector.java
@@ -1,0 +1,81 @@
+package ai.onehouse.metadata_extractor;
+
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FILE_SUFFIX;
+import static ai.onehouse.constants.MetadataExtractorConstants.ICEBERG_METADATA_FOLDER_NAME;
+
+import ai.onehouse.RuntimeModule.TableDiscoveryObjectStorageAsyncClient;
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.AsyncStorageClient;
+import ai.onehouse.storage.StorageUtils;
+import ai.onehouse.storage.models.File;
+import com.google.inject.Inject;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+
+/**
+ * A directory is an Iceberg table root if it contains a {@code metadata/} sub-directory <b>and</b>
+ * that sub-directory contains at least one {@code *.metadata.json} pointer file. The pointer-file
+ * check is what separates a real Iceberg table from any arbitrary folder that happens to have a
+ * sub-directory named {@code metadata} (a Spark checkpoint dir, a documentation folder, custom
+ * user layouts, etc.) — that name alone is too generic to be a reliable marker.
+ *
+ * <p>The validating LIST costs one extra storage call per candidate directory during discovery
+ * (not per upload cycle). Discovery already short-circuits recursion on a match, so the extra
+ * LIST runs at most once per real table and once per false-positive candidate during a discovery
+ * pass.
+ */
+public class IcebergTableFormatDetector implements TableFormatDetector {
+  private final AsyncStorageClient asyncStorageClient;
+  private final StorageUtils storageUtils;
+
+  @Inject
+  public IcebergTableFormatDetector(
+      @Nonnull @TableDiscoveryObjectStorageAsyncClient AsyncStorageClient asyncStorageClient,
+      @Nonnull StorageUtils storageUtils) {
+    this.asyncStorageClient = asyncStorageClient;
+    this.storageUtils = storageUtils;
+  }
+
+  @Override
+  public TableFormat format() {
+    return TableFormat.ICEBERG;
+  }
+
+  @Override
+  public CompletableFuture<Boolean> matches(String path, List<File> listedFiles) {
+    // S3 ListObjectsV2 surfaces "directories" as CommonPrefixes, which the storage client
+    // maps to File objects whose filename retains the trailing slash (e.g. "metadata/"),
+    // since that is exactly the Prefix string S3 returns. Strip a trailing slash before
+    // comparing so the check works regardless of whether the client preserves it.
+    boolean hasMetadataDir =
+        listedFiles.stream()
+            .anyMatch(
+                file -> {
+                  if (!file.isDirectory()) {
+                    return false;
+                  }
+                  String name = file.getFilename();
+                  if (name == null) {
+                    return false;
+                  }
+                  if (name.endsWith("/")) {
+                    name = name.substring(0, name.length() - 1);
+                  }
+                  return ICEBERG_METADATA_FOLDER_NAME.equals(name);
+                });
+    if (!hasMetadataDir) {
+      return CompletableFuture.completedFuture(false);
+    }
+    String metadataDirUri = storageUtils.constructFileUri(path, ICEBERG_METADATA_FOLDER_NAME);
+    return asyncStorageClient
+        .listAllFilesInDir(metadataDirUri)
+        .thenApply(
+            metadataFiles ->
+                metadataFiles.stream()
+                    .anyMatch(
+                        f ->
+                            !f.isDirectory()
+                                && f.getFilename().endsWith(ICEBERG_METADATA_FILE_SUFFIX)));
+  }
+}

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergTableFormatDetector.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/IcebergTableFormatDetector.java
@@ -44,10 +44,12 @@ public class IcebergTableFormatDetector implements TableFormatDetector {
 
   @Override
   public CompletableFuture<Boolean> matches(String path, List<File> listedFiles) {
-    // S3 ListObjectsV2 surfaces "directories" as CommonPrefixes, which the storage client
-    // maps to File objects whose filename retains the trailing slash (e.g. "metadata/"),
-    // since that is exactly the Prefix string S3 returns. Strip a trailing slash before
-    // comparing so the check works regardless of whether the client preserves it.
+    /*
+     * S3 ListObjectsV2 surfaces "directories" as CommonPrefixes, which the storage client
+     * maps to File objects whose filename retains the trailing slash (e.g. "metadata/"),
+     * since that is exactly the Prefix string S3 returns. Strip a trailing slash before
+     * comparing so the check works regardless of whether the client preserves it.
+     */
     boolean hasMetadataDir =
         listedFiles.stream()
             .anyMatch(

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJob.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJob.java
@@ -1,5 +1,6 @@
 package ai.onehouse.metadata_extractor;
 
+import ai.onehouse.api.models.request.TableFormat;
 import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.storage.AsyncStorageClient;
@@ -18,13 +19,17 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,6 +39,7 @@ import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataE
 public class TableDiscoveryAndUploadJob {
   private final TableDiscoveryService tableDiscoveryService;
   private final TableMetadataUploaderService tableMetadataUploaderService;
+  private final IcebergMetadataUploaderService icebergMetadataUploaderService;
   private final ScheduledExecutorService scheduler;
   private final Object lock = new Object();
   private final LakeViewExtractorMetrics hudiMetadataExtractorMetrics;
@@ -47,14 +53,39 @@ public class TableDiscoveryAndUploadJob {
   public TableDiscoveryAndUploadJob(
       @Nonnull TableDiscoveryService tableDiscoveryService,
       @Nonnull TableMetadataUploaderService tableMetadataUploaderService,
+      @Nonnull IcebergMetadataUploaderService icebergMetadataUploaderService,
       @Nonnull LakeViewExtractorMetrics hudiMetadataExtractorMetrics,
       @Nonnull @TableDiscoveryObjectStorageAsyncClient AsyncStorageClient asyncStorageClient) {
     this.scheduler = getScheduler();
     this.tableDiscoveryService = tableDiscoveryService;
     this.tableMetadataUploaderService = tableMetadataUploaderService;
+    this.icebergMetadataUploaderService = icebergMetadataUploaderService;
     this.hudiMetadataExtractorMetrics = hudiMetadataExtractorMetrics;
     this.firstCronRunStartTime = Instant.now();
     this.asyncStorageClient = asyncStorageClient;
+  }
+
+  /**
+   * Routes discovered tables to the appropriate per-format uploader and reduces to a single
+   * success boolean (all-or-nothing). Hudi and Iceberg tables are uploaded concurrently.
+   */
+  private CompletableFuture<Boolean> dispatchUpload(Set<Table> tables) {
+    Map<TableFormat, Set<Table>> byFormat =
+        tables.stream()
+            .collect(
+                Collectors.groupingBy(
+                    t -> t.getTableFormat() == null ? TableFormat.HUDI : t.getTableFormat(),
+                    Collectors.toSet()));
+    CompletableFuture<Boolean> hudiFuture =
+        tableMetadataUploaderService.uploadInstantsInTables(
+            byFormat.getOrDefault(TableFormat.HUDI, Collections.emptySet()));
+    CompletableFuture<Boolean> icebergFuture =
+        icebergMetadataUploaderService.uploadInstantsInTables(
+            byFormat.getOrDefault(TableFormat.ICEBERG, Collections.emptySet()));
+    // Treat a null result the same as success — the legacy contract on the Hudi uploader was
+    // "throw to fail," and downstream callers only inspect exceptions, not the boolean.
+    return hudiFuture.thenCombine(
+        icebergFuture, (a, b) -> !Boolean.FALSE.equals(a) && !Boolean.FALSE.equals(b));
   }
 
   /*
@@ -96,7 +127,7 @@ public class TableDiscoveryAndUploadJob {
     Boolean isSucceeded =
         tableDiscoveryService
             .discoverTables()
-            .thenCompose(tableMetadataUploaderService::uploadInstantsInTables)
+            .thenCompose(this::dispatchUpload)
             .join();
     if (Boolean.TRUE.equals(isSucceeded)) {
       log.info("Run Completed");
@@ -178,8 +209,7 @@ public class TableDiscoveryAndUploadJob {
         log.debug("Uploading table metadata for discovered tables");
         hudiMetadataExtractorMetrics.resetTableProcessedGauge();
         AtomicBoolean hasError = new AtomicBoolean(false);
-        tableMetadataUploaderService
-            .uploadInstantsInTables(tables)
+        dispatchUpload(tables)
             .exceptionally(
                 ex -> {
                   log.error("Error uploading instants in tables: ", ex);

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJob.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJob.java
@@ -82,8 +82,10 @@ public class TableDiscoveryAndUploadJob {
     CompletableFuture<Boolean> icebergFuture =
         icebergMetadataUploaderService.uploadInstantsInTables(
             byFormat.getOrDefault(TableFormat.ICEBERG, Collections.emptySet()));
-    // Treat a null result the same as success — the legacy contract on the Hudi uploader was
-    // "throw to fail," and downstream callers only inspect exceptions, not the boolean.
+    /*
+     * Treat a null result the same as success — the legacy contract on the Hudi uploader was
+     * "throw to fail," and downstream callers only inspect exceptions, not the boolean.
+     */
     return hudiFuture.thenCombine(
         icebergFuture, (a, b) -> !Boolean.FALSE.equals(a) && !Boolean.FALSE.equals(b));
   }

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -77,9 +77,11 @@ public class TableDiscoveryService {
     log.info("Starting table discover service, excluding {}", excludedPathPatterns);
     List<Pair<String, CompletableFuture<Set<Table>>>> pathToDiscoveredTablesFuturePairList =
         new ArrayList<>();
-    // Merge per-database tableHints into a single tableId -> hint map. Hints are optional metadata
-    // supplied by the control plane (e.g. Iceberg metadata_location) and are looked up after
-    // discovery, once the tableId is known.
+    /*
+     * Merge per-database tableHints into a single tableId -> hint map. Hints are optional metadata
+     * supplied by the control plane (e.g. Iceberg metadata_location) and are looked up after
+     * discovery, once the tableId is known.
+     */
     Map<String, TableHint> tableHintsByTableId = new HashMap<>();
     for (ParserConfig parserConfig : metadataExtractorConfig.getParserConfig()) {
       for (Database database : parserConfig.getDatabases()) {
@@ -144,9 +146,11 @@ public class TableDiscoveryService {
                   }
                   Table table = discoveredTables.iterator().next();
                   Table.TableBuilder builder = table.toBuilder().tableId(tableId);
-                  // metadataLocationHint is only applied here, on base paths pinned with an
-                  // explicit "#tableId". Auto-discovered tables (no tableId in the config) never
-                  // carry a hint and always fall back to listing metadata/ at upload time.
+                  /*
+                   * metadataLocationHint is only applied here, on base paths pinned with an
+                   * explicit "#tableId". Auto-discovered tables (no tableId in the config) never
+                   * carry a hint and always fall back to listing metadata/ at upload time.
+                   */
                   TableHint hint = tableHintsByTableId.get(tableId);
                   if (hint != null && StringUtils.isNotBlank(hint.getMetadataLocationHint())) {
                     builder.metadataLocationHint(hint.getMetadataLocationHint());

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -9,6 +9,7 @@ import ai.onehouse.config.ConfigProvider;
 import ai.onehouse.config.models.configv1.Database;
 import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.config.models.configv1.ParserConfig;
+import ai.onehouse.config.models.configv1.TableHint;
 import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.metadata_extractor.models.Table;
 import ai.onehouse.metrics.LakeViewExtractorMetrics;
@@ -19,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -54,13 +56,17 @@ public class TableDiscoveryService {
       @Nonnull ConfigProvider configProvider,
       @Nonnull ExecutorService executorService,
       @Nonnull LakeViewExtractorMetrics lakeviewExtractorMetrics,
-      @Nonnull HudiTableFormatDetector hudiTableFormatDetector) {
+      @Nonnull HudiTableFormatDetector hudiTableFormatDetector,
+      @Nonnull IcebergTableFormatDetector icebergTableFormatDetector) {
     this.asyncStorageClient = asyncStorageClient;
     this.storageUtils = storageUtils;
     this.executorService = executorService;
     this.configProvider = configProvider;
     this.lakeviewExtractorMetrics = lakeviewExtractorMetrics;
-    this.detectorsByFormat = ImmutableMap.of(TableFormat.HUDI, hudiTableFormatDetector);
+    this.detectorsByFormat =
+        ImmutableMap.of(
+            TableFormat.HUDI, hudiTableFormatDetector,
+            TableFormat.ICEBERG, icebergTableFormatDetector);
   }
 
   public CompletableFuture<Set<Table>> discoverTables() {
@@ -71,6 +77,25 @@ public class TableDiscoveryService {
     log.info("Starting table discover service, excluding {}", excludedPathPatterns);
     List<Pair<String, CompletableFuture<Set<Table>>>> pathToDiscoveredTablesFuturePairList =
         new ArrayList<>();
+    // Merge per-database tableHints into a single tableId -> hint map. Hints are optional metadata
+    // supplied by the control plane (e.g. Iceberg metadata_location) and are looked up after
+    // discovery, once the tableId is known.
+    Map<String, TableHint> tableHintsByTableId = new HashMap<>();
+    for (ParserConfig parserConfig : metadataExtractorConfig.getParserConfig()) {
+      for (Database database : parserConfig.getDatabases()) {
+        if (database.getTableHints() == null) {
+          continue;
+        }
+        for (Map.Entry<String, TableHint> entry : database.getTableHints().entrySet()) {
+          TableHint previous = tableHintsByTableId.put(entry.getKey(), entry.getValue());
+          if (previous != null) {
+            log.warn(
+                "Duplicate tableHint for tableId {} across databases; later entry wins.",
+                entry.getKey());
+          }
+        }
+      }
+    }
 
     for (ParserConfig parserConfig : metadataExtractorConfig.getParserConfig()) {
       for (Database database : parserConfig.getDatabases()) {
@@ -118,7 +143,15 @@ public class TableDiscoveryService {
                     continue;
                   }
                   Table table = discoveredTables.iterator().next();
-                  table = table.toBuilder().tableId(tableId).build();
+                  Table.TableBuilder builder = table.toBuilder().tableId(tableId);
+                  // metadataLocationHint is only applied here, on base paths pinned with an
+                  // explicit "#tableId". Auto-discovered tables (no tableId in the config) never
+                  // carry a hint and always fall back to listing metadata/ at upload time.
+                  TableHint hint = tableHintsByTableId.get(tableId);
+                  if (hint != null && StringUtils.isNotBlank(hint.getMetadataLocationHint())) {
+                    builder.metadataLocationHint(hint.getMetadataLocationHint());
+                  }
+                  table = builder.build();
                   discoveredTables = Collections.singleton(table);
                 }
 
@@ -129,12 +162,10 @@ public class TableDiscoveryService {
   }
 
   private TableFormatDetector detectorFor(Database database) {
-    TableFormat declared =
-        database.getTableFormat() == null ? TableFormat.HUDI : database.getTableFormat();
+    TableFormat declared = database.getTableFormat() == null ? TableFormat.HUDI : database.getTableFormat();
     TableFormatDetector detector = detectorsByFormat.get(declared);
     if (detector == null) {
-      // Programmer error: a TableFormat enum value was added without a matching detector. With
-      // only HUDI registered today, this fires if a YAML declares any other format.
+      // Programmer error: a new TableFormat enum value was added without a matching detector.
       throw new IllegalStateException("No detector registered for tableFormat=" + declared);
     }
     return detector;
@@ -173,6 +204,7 @@ public class TableDiscoveryService {
                                       .absoluteTableUri(path)
                                       .databaseName(databaseName)
                                       .lakeName(lakeName)
+                                      .tableFormat(detector.format())
                                       .build();
                               if (!isExcluded(table.getAbsoluteTableUri(), excludedPathPatterns)) {
                                 tablePaths.add(table);
@@ -184,7 +216,6 @@ public class TableDiscoveryService {
                                 listedFiles.stream()
                                     .filter(File::isDirectory)
                                     .collect(Collectors.toList());
-
                             List<CompletableFuture<Void>> recursiveFutures = new ArrayList<>();
                             for (File file : directories) {
                               String filePath =
@@ -201,7 +232,6 @@ public class TableDiscoveryService {
                                 recursiveFutures.add(recursiveFuture);
                               }
                             }
-
                             return CompletableFuture.allOf(
                                     recursiveFutures.toArray(new CompletableFuture[0]))
                                 .thenApplyAsync(ignored -> tablePaths, executorService);

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/models/Table.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/models/Table.java
@@ -3,6 +3,7 @@ package ai.onehouse.metadata_extractor.models;
 import static ai.onehouse.constants.MetadataExtractorConstants.HOODIE_TABLE_VERSION_DEFAULT;
 import static ai.onehouse.constants.MetadataExtractorConstants.TIMELINE_LAYOUT_VERSION_DEFAULT;
 
+import ai.onehouse.api.models.request.TableFormat;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -20,4 +21,13 @@ public class Table {
   private String tableId;
   @Builder.Default private final int tableVersion = HOODIE_TABLE_VERSION_DEFAULT;
   @Builder.Default private final int timelineLayoutVersion = TIMELINE_LAYOUT_VERSION_DEFAULT;
+  // tableVersion / timelineLayoutVersion above are Hudi-specific and ignored for non-Hudi formats.
+  @Builder.Default private final TableFormat tableFormat = TableFormat.HUDI;
+  /**
+   * Optional URI of the current Iceberg {@code metadata.json}, supplied by the control plane via
+   * the parser YAML's table hints. Null when no hint was provided. {@link
+   * ai.onehouse.metadata_extractor.IcebergMetadataUploaderService} uses this to skip the per-cycle
+   * {@code metadata/} folder LIST when the hint matches the last uploaded file.
+   */
+  private final String metadataLocationHint;
 }

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
@@ -4,12 +4,14 @@ import static ai.onehouse.constants.MetadataExtractorConstants.PROCESS_TABLE_MET
 import static ai.onehouse.constants.MetadataExtractorConstants.TABLE_DISCOVERY_INTERVAL_MINUTES;
 import static org.mockito.Mockito.*;
 
+import ai.onehouse.api.models.request.TableFormat;
 import ai.onehouse.config.Config;
 import ai.onehouse.config.models.configv1.MetadataExtractorConfig;
 import ai.onehouse.constants.MetricsConstants;
 import ai.onehouse.exceptions.RateLimitException;
 import ai.onehouse.metadata_extractor.models.Table;
 import ai.onehouse.metrics.LakeViewExtractorMetrics;
+import com.google.common.collect.ImmutableSet;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -40,6 +42,7 @@ class TableDiscoveryAndUploadJobTest {
   @Mock private TableDiscoveryService mockTableDiscoveryService;
 
   @Mock private TableMetadataUploaderService mockTableMetadataUploaderService;
+  @Mock private IcebergMetadataUploaderService mockIcebergMetadataUploaderService;
 
   @Mock private ScheduledExecutorService mockScheduler;
 
@@ -56,6 +59,12 @@ class TableDiscoveryAndUploadJobTest {
 
   @BeforeEach
   void setUp(TestInfo info) {
+    // Existing tests exercise the Hudi path; dispatch routes any Iceberg-format tables (none in
+    // these tests) to the Iceberg uploader. Default the mock to a successful no-op so the dispatch
+    // combine doesn't NPE on the (empty Iceberg set) branch.
+    lenient()
+        .when(mockIcebergMetadataUploaderService.uploadInstantsInTables(anySet()))
+        .thenReturn(CompletableFuture.completedFuture(true));
     Instant fixedInstant =
         info.getDisplayName().startsWith("2023") ? Instant.parse(info.getDisplayName()) : Instant.now();
     try (MockedStatic<Instant> mockedInstant =
@@ -65,6 +74,7 @@ class TableDiscoveryAndUploadJobTest {
           new TableDiscoveryAndUploadJob(
               mockTableDiscoveryService,
               mockTableMetadataUploaderService,
+              mockIcebergMetadataUploaderService,
               mockHudiMetadataExtractorMetrics,
               asyncStorageClient) {
             @Override
@@ -171,6 +181,39 @@ class TableDiscoveryAndUploadJobTest {
     verify(mockTableDiscoveryService, times(1)).discoverTables();
     verify(mockTableMetadataUploaderService, times(1))
         .uploadInstantsInTables(Collections.singleton(discoveredTable));
+  }
+
+  @Test
+  void testDispatchRoutesTablesByFormat() {
+    Table hudiTable =
+        Table.builder()
+            .absoluteTableUri("s3://bucket/hudi_db/t")
+            .lakeName("lake")
+            .databaseName("hudi_db")
+            .tableFormat(TableFormat.HUDI)
+            .build();
+    Table icebergTable =
+        Table.builder()
+            .absoluteTableUri("s3://bucket/iceberg_db/t")
+            .lakeName("lake")
+            .databaseName("iceberg_db")
+            .tableFormat(TableFormat.ICEBERG)
+            .build();
+    when(mockTableDiscoveryService.discoverTables())
+        .thenReturn(
+            CompletableFuture.completedFuture(ImmutableSet.of(hudiTable, icebergTable)));
+    when(mockTableMetadataUploaderService.uploadInstantsInTables(anySet()))
+        .thenReturn(CompletableFuture.completedFuture(true));
+    when(mockIcebergMetadataUploaderService.uploadInstantsInTables(anySet()))
+        .thenReturn(CompletableFuture.completedFuture(true));
+
+    job.runOnce();
+
+    // Each uploader receives exactly its own format's partition — never the other's.
+    verify(mockTableMetadataUploaderService)
+        .uploadInstantsInTables(Collections.singleton(hudiTable));
+    verify(mockIcebergMetadataUploaderService)
+        .uploadInstantsInTables(Collections.singleton(icebergTable));
   }
 
   @ParameterizedTest(name = "{0}")

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
@@ -59,9 +59,11 @@ class TableDiscoveryAndUploadJobTest {
 
   @BeforeEach
   void setUp(TestInfo info) {
-    // Existing tests exercise the Hudi path; dispatch routes any Iceberg-format tables (none in
-    // these tests) to the Iceberg uploader. Default the mock to a successful no-op so the dispatch
-    // combine doesn't NPE on the (empty Iceberg set) branch.
+    /*
+     * Existing tests exercise the Hudi path; dispatch routes any Iceberg-format tables (none in
+     * these tests) to the Iceberg uploader. Default the mock to a successful no-op so the dispatch
+     * combine doesn't NPE on the (empty Iceberg set) branch.
+     */
     lenient()
         .when(mockIcebergMetadataUploaderService.uploadInstantsInTables(anySet()))
         .thenReturn(CompletableFuture.completedFuture(true));

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryAndUploadJobTest.java
@@ -59,14 +59,6 @@ class TableDiscoveryAndUploadJobTest {
 
   @BeforeEach
   void setUp(TestInfo info) {
-    /*
-     * Existing tests exercise the Hudi path; dispatch routes any Iceberg-format tables (none in
-     * these tests) to the Iceberg uploader. Default the mock to a successful no-op so the dispatch
-     * combine doesn't NPE on the (empty Iceberg set) branch.
-     */
-    lenient()
-        .when(mockIcebergMetadataUploaderService.uploadInstantsInTables(anySet()))
-        .thenReturn(CompletableFuture.completedFuture(true));
     Instant fixedInstant =
         info.getDisplayName().startsWith("2023") ? Instant.parse(info.getDisplayName()) : Instant.now();
     try (MockedStatic<Instant> mockedInstant =
@@ -121,6 +113,8 @@ class TableDiscoveryAndUploadJobTest {
                 Collections.singleton(discoveredTable)))
             .thenReturn(CompletableFuture.completedFuture(null));
       }
+      when(mockIcebergMetadataUploaderService.uploadInstantsInTables(Collections.emptySet()))
+          .thenReturn(CompletableFuture.completedFuture(true));
     }
 
     when(config.getMetadataExtractorConfig().getTableDiscoveryIntervalMinutes())
@@ -179,6 +173,8 @@ class TableDiscoveryAndUploadJobTest {
     when(mockTableMetadataUploaderService.uploadInstantsInTables(
             Collections.singleton(discoveredTable)))
         .thenReturn(CompletableFuture.completedFuture(isSucceeded));
+    when(mockIcebergMetadataUploaderService.uploadInstantsInTables(Collections.emptySet()))
+        .thenReturn(CompletableFuture.completedFuture(true));
     job.runOnce();
     verify(mockTableDiscoveryService, times(1)).discoverTables();
     verify(mockTableMetadataUploaderService, times(1))
@@ -232,6 +228,8 @@ class TableDiscoveryAndUploadJobTest {
     when(mockTableMetadataUploaderService.uploadInstantsInTables(
         Collections.singleton(discoveredTable)))
         .thenReturn(CompletableFuture.completedFuture(isSucceeded));
+    when(mockIcebergMetadataUploaderService.uploadInstantsInTables(Collections.emptySet()))
+        .thenReturn(CompletableFuture.completedFuture(true));
     when(config.getMetadataExtractorConfig().getJobRunMode())
         .thenReturn(MetadataExtractorConfig.JobRunMode.ONCE_WITH_RETRY);
     if (!isSucceeded) {

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
@@ -165,7 +165,8 @@ class TableDiscoveryServiceTest {
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
             hudiMetadataExtractorMetrics,
-            new HudiTableFormatDetector());
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils()));
 
     Set<Table> tableSet = tableDiscoveryService.discoverTables().get();
     List<Table> expectedResponseSet =
@@ -258,7 +259,8 @@ class TableDiscoveryServiceTest {
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
             hudiMetadataExtractorMetrics,
-            new HudiTableFormatDetector());
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils()));
 
     Set<Table> discoveredTables = tableDiscoveryService.discoverTables().join();
     assertEquals(emptySet(), discoveredTables);
@@ -297,7 +299,8 @@ class TableDiscoveryServiceTest {
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
             hudiMetadataExtractorMetrics,
-            new HudiTableFormatDetector());
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector(s3AsyncStorageClient, new StorageUtils()));
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
   }
 
@@ -330,7 +333,8 @@ class TableDiscoveryServiceTest {
             new ConfigProvider(config),
             ForkJoinPool.commonPool(),
             hudiMetadataExtractorMetrics,
-            new HudiTableFormatDetector());
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils()));
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
   }
 
@@ -362,7 +366,8 @@ class TableDiscoveryServiceTest {
                     new ConfigProvider(config),
                     ForkJoinPool.commonPool(),
                     hudiMetadataExtractorMetrics,
-            new HudiTableFormatDetector());
+                    new HudiTableFormatDetector(),
+                    new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils()));
 
     assertEquals(emptySet(), tableDiscoveryService.discoverTables().join());
 
@@ -370,6 +375,72 @@ class TableDiscoveryServiceTest {
     verify(hudiMetadataExtractorMetrics)
             .incrementTableDiscoveryFailureCounter(
                     MetricsConstants.MetadataUploadFailureReasons.RATE_LIMITING);
+  }
+
+  @Test
+  void testDiscoverIcebergTableByDeclaredFormat() {
+    // Database declared as ICEBERG. Two children: `orders/` is a real Iceberg table (metadata/
+    // with a *.metadata.json), `docs/` is a false-positive shape (metadata/ but no .metadata.json
+    // inside) and must be skipped.
+    String basePath = "s3://bucket/iceberg_warehouse/";
+    String ordersPath = basePath + "orders/";
+    String ordersMetadata = ordersPath + "metadata";
+    String docsPath = basePath + "docs/";
+    String docsMetadata = docsPath + "metadata";
+
+    when(asyncStorageClient.listAllFilesInDir(basePath))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(generateFileObj("orders/", true), generateFileObj("docs/", true))));
+    when(asyncStorageClient.listAllFilesInDir(ordersPath))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(
+                    generateFileObj("metadata", true), generateFileObj("data", true))));
+    when(asyncStorageClient.listAllFilesInDir(ordersMetadata))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(generateFileObj("v1.metadata.json", false))));
+    when(asyncStorageClient.listAllFilesInDir(docsPath))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(generateFileObj("metadata", true))));
+    when(asyncStorageClient.listAllFilesInDir(docsMetadata))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(generateFileObj("README.md", false))));
+
+    when(config.getMetadataExtractorConfig()).thenReturn(metadataExtractorConfig);
+    when(metadataExtractorConfig.getPathExclusionPatterns()).thenReturn(Optional.of(emptyList()));
+    when(metadataExtractorConfig.getParserConfig())
+        .thenReturn(
+            Collections.singletonList(
+                ParserConfig.builder()
+                    .lake(LAKE)
+                    .databases(
+                        Collections.singletonList(
+                            Database.builder()
+                                .name(DATABASE)
+                                .tableFormat(ai.onehouse.api.models.request.TableFormat.ICEBERG)
+                                .basePaths(Collections.singletonList(basePath))
+                                .build()))
+                    .build()));
+
+    tableDiscoveryService =
+        new TableDiscoveryService(
+            asyncStorageClient,
+            new StorageUtils(),
+            new ConfigProvider(config),
+            ForkJoinPool.commonPool(),
+            hudiMetadataExtractorMetrics,
+            new HudiTableFormatDetector(),
+            new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils()));
+
+    Set<Table> tables = tableDiscoveryService.discoverTables().join();
+    assertEquals(1, tables.size());
+    Table only = tables.iterator().next();
+    assertEquals(ordersPath, only.getAbsoluteTableUri());
+    assertEquals(ai.onehouse.api.models.request.TableFormat.ICEBERG, only.getTableFormat());
   }
 
   private File generateFileObj(String fileName, boolean isDirectory) {

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
@@ -379,9 +379,11 @@ class TableDiscoveryServiceTest {
 
   @Test
   void testDiscoverIcebergTableByDeclaredFormat() {
-    // Database declared as ICEBERG. Two children: `orders/` is a real Iceberg table (metadata/
-    // with a *.metadata.json), `docs/` is a false-positive shape (metadata/ but no .metadata.json
-    // inside) and must be skipped.
+    /*
+     * Database declared as ICEBERG. Two children: `orders/` is a real Iceberg table (metadata/
+     * with a *.metadata.json), `docs/` is a false-positive shape (metadata/ but no .metadata.json
+     * inside) and must be skipped.
+     */
     String basePath = "s3://bucket/iceberg_warehouse/";
     String ordersPath = basePath + "orders/";
     String ordersMetadata = ordersPath + "metadata";

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
@@ -1,0 +1,538 @@
+package ai.onehouse.metadata_extractor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import ai.onehouse.api.OnehouseApiClient;
+import ai.onehouse.api.models.request.GenerateCommitMetadataUploadUrlRequest;
+import ai.onehouse.api.models.request.InitializeTableMetricsCheckpointRequest;
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.api.models.request.UpsertTableMetricsCheckpointRequest;
+import ai.onehouse.api.models.response.ApiResponse;
+import ai.onehouse.api.models.response.GenerateCommitMetadataUploadUrlResponse;
+import ai.onehouse.api.models.response.GetTableMetricsCheckpointResponse;
+import ai.onehouse.api.models.response.InitializeTableMetricsCheckpointResponse;
+import ai.onehouse.api.models.response.UpsertTableMetricsCheckpointResponse;
+import ai.onehouse.constants.MetricsConstants;
+import ai.onehouse.metadata_extractor.models.Checkpoint;
+import ai.onehouse.metadata_extractor.models.Table;
+import ai.onehouse.metrics.LakeViewExtractorMetrics;
+import ai.onehouse.storage.AsyncStorageClient;
+import ai.onehouse.storage.PresignedUrlFileUploader;
+import ai.onehouse.storage.StorageUtils;
+import ai.onehouse.storage.models.File;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.common.collect.ImmutableSet;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TestIcebergMetadataUploaderService {
+
+  private static final String TABLE_ID = "table-1";
+  private static final String TABLE_URI = "s3://bucket/db/t";
+  private static final String LAKE = "lake";
+  private static final String DATABASE = "db";
+
+  @Mock private OnehouseApiClient apiClient;
+  @Mock private AsyncStorageClient storageClient;
+  @Mock private PresignedUrlFileUploader uploader;
+  @Mock private LakeViewExtractorMetrics metrics;
+
+  private final StorageUtils storageUtils = new StorageUtils();
+  private final String metadataDir = storageUtils.constructFileUri(TABLE_URI, "metadata");
+  private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+  private IcebergMetadataUploaderService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new IcebergMetadataUploaderService(
+            storageClient, apiClient, uploader, storageUtils, metrics);
+  }
+
+  // ---------------------------------------------------------------------------
+  // uploadInstantsInTables / aggregation
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void emptyTableSetCompletesTrueWithoutApiCalls() {
+    assertTrue(service.uploadInstantsInTables(Collections.emptySet()).join());
+    verifyNoInteractions(apiClient);
+    verifyNoInteractions(storageClient);
+  }
+
+  @Test
+  void multiTableOneFailureAggregatesToFalse() {
+    Table ok = icebergTable(TABLE_ID, null);
+    Table bad = icebergTable("table-2", null);
+    // table-1: up-to-date no-op (true). table-2: checkpoint fetch fails (false).
+    when(apiClient.getTableMetricsCheckpoints(Collections.singletonList(TABLE_ID)))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v1.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(completed(Collections.singletonList(jsonFile("v1.metadata.json"))));
+    when(apiClient.getTableMetricsCheckpoints(Collections.singletonList("table-2")))
+        .thenReturn(failed(new GetTableMetricsCheckpointResponse(), 500, "boom"));
+
+    assertFalse(service.uploadInstantsInTables(ImmutableSet.of(ok, bad)).join());
+  }
+
+  // ---------------------------------------------------------------------------
+  // checkpoint fetch / parse
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void checkpointFetchFailureReturnsFalseAndIncrementsMetric() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(failed(new GetTableMetricsCheckpointResponse(), 503, "down"));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR), anyString());
+    verify(apiClient, never()).generateCommitMetadataUploadUrl(any());
+  }
+
+  @Test
+  void processTableExceptionIncrementsUnknownAndReturnsFalse() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(failedFuture(new RuntimeException("kaboom")));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.UNKNOWN), anyString());
+  }
+
+  @Test
+  void malformedCheckpointIsTreatedAsMissingAndInitialises() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, "{not-valid-json"));
+    when(apiClient.initializeTableMetricsCheckpoint(any())).thenReturn(initOk());
+    // INITIAL_CHECKPOINT has lastUploadedFile="", so v1 is new -> full upload.
+    stubFullUpload(Collections.singletonList(jsonFile("v1.metadata.json")));
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(apiClient)
+        .initializeTableMetricsCheckpoint(any(InitializeTableMetricsCheckpointRequest.class));
+  }
+
+  // ---------------------------------------------------------------------------
+  // initialise path
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void noCheckpointInitialisesThenUploads() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, null)); // blank checkpoint -> missing
+    when(apiClient.initializeTableMetricsCheckpoint(any())).thenReturn(initOk());
+    stubFullUpload(Collections.singletonList(jsonFile("v1.metadata.json")));
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(apiClient)
+        .initializeTableMetricsCheckpoint(any(InitializeTableMetricsCheckpointRequest.class));
+    verify(metrics).incrementMetadataUploadSuccessCounter();
+  }
+
+  @Test
+  void initFailureReturnsFalseAndIncrementsMetric() {
+    when(apiClient.getTableMetricsCheckpoints(anyList())).thenReturn(okCheckpoint(TABLE_ID, null));
+    when(apiClient.initializeTableMetricsCheckpoint(any()))
+        .thenReturn(failed(new InitializeTableMetricsCheckpointResponse(), 500, "init failed"));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR), anyString());
+    verify(apiClient, never()).generateCommitMetadataUploadUrl(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // fallback listing path
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void fallbackUpToDateIsNoOp() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v3.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(
+            completed(
+                Arrays.asList(jsonFile("v2.metadata.json"), jsonFile("v3.metadata.json"))));
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(apiClient, never()).generateCommitMetadataUploadUrl(any());
+  }
+
+  @Test
+  void fallbackAdvancesUploadsAndUpserts() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v2.metadata.json")));
+    stubFullUpload(Arrays.asList(jsonFile("v2.metadata.json"), jsonFile("v3.metadata.json")));
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(uploader).uploadFileToPresignedUrl(eq("https://presigned"), anyString(), anyInt());
+    verify(metrics).incrementMetadataUploadSuccessCounter();
+    verify(apiClient).upsertTableMetricsCheckpoint(any(UpsertTableMetricsCheckpointRequest.class));
+  }
+
+  @Test
+  void noMetadataJsonReturnsFalseWithNoSuchKey() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v1.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(completed(Collections.singletonList(jsonFile("README.md"))));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.NO_SUCH_KEY), anyString());
+  }
+
+  // ---------------------------------------------------------------------------
+  // version-hint.text resolution
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void versionHintResolvesTargetAndUploads() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v1.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(
+            completed(
+                Arrays.asList(
+                    jsonFile("version-hint.text"),
+                    jsonFile("v1.metadata.json"),
+                    jsonFile("v2.metadata.json"),
+                    jsonFile("v7.metadata.json"))));
+    when(storageClient.readFileAsBytes(
+            storageUtils.constructFileUri(metadataDir, "version-hint.text")))
+        .thenReturn(completed("7".getBytes(StandardCharsets.UTF_8)));
+    stubGenerateUpload();
+    when(apiClient.upsertTableMetricsCheckpoint(any())).thenReturn(upsertOk());
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(apiClient).generateCommitMetadataUploadUrl(argThatCommitInstantIs("v7.metadata.json"));
+  }
+
+  @Test
+  void versionHintReadFailureFallsBackToNumericSort() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v5.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(
+            completed(
+                Arrays.asList(
+                    jsonFile("version-hint.text"),
+                    jsonFile("v5.metadata.json"),
+                    jsonFile("v6.metadata.json"))));
+    when(storageClient.readFileAsBytes(anyString()))
+        .thenReturn(failedFuture(new RuntimeException("read failed")));
+    stubGenerateUpload();
+    when(apiClient.upsertTableMetricsCheckpoint(any())).thenReturn(upsertOk());
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(apiClient).generateCommitMetadataUploadUrl(argThatCommitInstantIs("v6.metadata.json"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // metadataLocationHint fast path
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void hintPathUpToDateSkipsListing() {
+    String hint = "s3://bucket/db/t/metadata/v9.metadata.json";
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v9.metadata.json")));
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, hint))).join());
+    verify(storageClient, never()).listAllFilesInDir(anyString());
+    verify(apiClient, never()).generateCommitMetadataUploadUrl(any());
+  }
+
+  @Test
+  void hintPathUploadsWhenAdvancedWithoutListing() {
+    String hint = "s3a://bucket/db/t/metadata/v9.metadata.json";
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v8.metadata.json")));
+    stubGenerateUpload();
+    when(apiClient.upsertTableMetricsCheckpoint(any())).thenReturn(upsertOk());
+
+    assertTrue(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, hint))).join());
+    verify(storageClient, never()).listAllFilesInDir(anyString());
+    verify(uploader).uploadFileToPresignedUrl(eq("https://presigned"), eq(hint), anyInt());
+    verify(apiClient).generateCommitMetadataUploadUrl(argThatCommitInstantIs("v9.metadata.json"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // upload / upsert failure branches
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void presignedUrlFailureReturnsFalse() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v1.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(completed(Collections.singletonList(jsonFile("v2.metadata.json"))));
+    when(apiClient.generateCommitMetadataUploadUrl(any()))
+        .thenReturn(failed(new GenerateCommitMetadataUploadUrlResponse(), 500, "no url"));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.PRESIGNED_URL_UPLOAD_FAILURE),
+            anyString());
+    verify(uploader, never()).uploadFileToPresignedUrl(anyString(), anyString(), anyInt());
+  }
+
+  @Test
+  void upsertFailureReturnsFalseAfterSuccessfulUpload() {
+    when(apiClient.getTableMetricsCheckpoints(anyList()))
+        .thenReturn(okCheckpoint(TABLE_ID, checkpointJson("v1.metadata.json")));
+    when(storageClient.listAllFilesInDir(metadataDir))
+        .thenReturn(completed(Collections.singletonList(jsonFile("v2.metadata.json"))));
+    stubGenerateUpload();
+    when(apiClient.upsertTableMetricsCheckpoint(any()))
+        .thenReturn(failed(new UpsertTableMetricsCheckpointResponse(), 500, "upsert failed"));
+
+    assertFalse(service.uploadInstantsInTables(singleton(icebergTable(TABLE_ID, null))).join());
+    verify(metrics).incrementMetadataUploadSuccessCounter(); // upload itself succeeded
+    verify(metrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR), anyString());
+  }
+
+  // ===========================================================================
+  // Static helper tests (pure, no mocks)
+  // ===========================================================================
+
+  @Test
+  void picksLatestHiveGlueStyleMetadataJsonByNumericPrefix() {
+    Optional<File> latest =
+        IcebergMetadataUploaderService.pickLatestMetadataJson(
+            Arrays.asList(
+                jsonFile("00000-abc.metadata.json"),
+                jsonFile("00020-xyz.metadata.json"),
+                jsonFile("00005-def.metadata.json")));
+    assertTrue(latest.isPresent());
+    assertEquals("00020-xyz.metadata.json", latest.get().getFilename());
+  }
+
+  @Test
+  void picksLatestHadoopCatalogMetadataJsonByVersionNumber() {
+    Optional<File> latest =
+        IcebergMetadataUploaderService.pickLatestMetadataJson(
+            Arrays.asList(
+                jsonFile("v1.metadata.json"),
+                jsonFile("v2.metadata.json"),
+                jsonFile("v9.metadata.json"),
+                jsonFile("v10.metadata.json"),
+                jsonFile("v11.metadata.json")));
+    assertTrue(latest.isPresent());
+    assertEquals("v11.metadata.json", latest.get().getFilename());
+  }
+
+  @Test
+  void ignoresDirectoriesAndUnrelatedFiles() {
+    Optional<File> latest =
+        IcebergMetadataUploaderService.pickLatestMetadataJson(
+            Arrays.asList(
+                jsonFile("snap-x.avro"),
+                File.builder().filename("sub").isDirectory(true).lastModifiedAt(Instant.EPOCH).build(),
+                jsonFile("00001-a.metadata.json")));
+    assertTrue(latest.isPresent());
+    assertEquals("00001-a.metadata.json", latest.get().getFilename());
+  }
+
+  @Test
+  void returnsEmptyWhenNoMetadataJson() {
+    assertFalse(
+        IcebergMetadataUploaderService.pickLatestMetadataJson(
+                Collections.singletonList(jsonFile("snap.avro")))
+            .isPresent());
+  }
+
+  @Test
+  void extractVersionNumberHandlesAllNamingShapes() {
+    assertEquals(10L, IcebergMetadataUploaderService.extractVersionNumber("v10.metadata.json"));
+    assertEquals(
+        20L, IcebergMetadataUploaderService.extractVersionNumber("00020-uuid.metadata.json"));
+    assertEquals(
+        0L, IcebergMetadataUploaderService.extractVersionNumber("00000-uuid.metadata.json"));
+    assertEquals(-1L, IcebergMetadataUploaderService.extractVersionNumber("metadata.json"));
+    assertEquals(-1L, IcebergMetadataUploaderService.extractVersionNumber("v.metadata.json"));
+  }
+
+  @Test
+  void resolveFromVersionHintReturnsTargetWhenPresent() {
+    Optional<File> resolved =
+        IcebergMetadataUploaderService.resolveFromVersionHint(
+            "7\n".getBytes(StandardCharsets.UTF_8),
+            Arrays.asList(
+                jsonFile("v6.metadata.json"),
+                jsonFile("v7.metadata.json"),
+                jsonFile("v8.metadata.json")));
+    assertTrue(resolved.isPresent());
+    assertEquals("v7.metadata.json", resolved.get().getFilename());
+  }
+
+  @Test
+  void resolveFromVersionHintReturnsEmptyWhenTargetMissing() {
+    assertFalse(
+        IcebergMetadataUploaderService.resolveFromVersionHint(
+                "42".getBytes(StandardCharsets.UTF_8),
+                Arrays.asList(jsonFile("v6.metadata.json"), jsonFile("v7.metadata.json")))
+            .isPresent());
+  }
+
+  @Test
+  void resolveFromVersionHintReturnsEmptyOnNonIntegerContent() {
+    assertFalse(
+        IcebergMetadataUploaderService.resolveFromVersionHint(
+                "not-an-int".getBytes(StandardCharsets.UTF_8),
+                Collections.singletonList(jsonFile("v1.metadata.json")))
+            .isPresent());
+  }
+
+  @Test
+  void lastPathSegmentExtractsFilenameFromUri() {
+    assertEquals(
+        "00042-uuid.metadata.json",
+        IcebergMetadataUploaderService.lastPathSegment(
+            "s3://bucket/db/t/metadata/00042-uuid.metadata.json"));
+    assertEquals(
+        "v3.metadata.json",
+        IcebergMetadataUploaderService.lastPathSegment(
+            "s3a://bucket/db/t/metadata/v3.metadata.json"));
+  }
+
+  @Test
+  void lastPathSegmentReturnsInputWhenNoSlash() {
+    assertEquals("filename.json", IcebergMetadataUploaderService.lastPathSegment("filename.json"));
+  }
+
+  // ===========================================================================
+  // helpers
+  // ===========================================================================
+
+  private static Set<Table> singleton(Table t) {
+    return Collections.singleton(t);
+  }
+
+  private static Table icebergTable(String tableId, String metadataLocationHint) {
+    return Table.builder()
+        .tableId(tableId)
+        .absoluteTableUri(TABLE_URI)
+        .lakeName(LAKE)
+        .databaseName(DATABASE)
+        .tableFormat(TableFormat.ICEBERG)
+        .metadataLocationHint(metadataLocationHint)
+        .build();
+  }
+
+  private String checkpointJson(String lastUploadedFile) {
+    Checkpoint checkpoint =
+        Checkpoint.builder()
+            .batchId(1)
+            .checkpointTimestamp(Instant.EPOCH)
+            .lastUploadedFile(lastUploadedFile)
+            .firstIncompleteCommitFile("")
+            .archivedCommitsProcessed(true)
+            .build();
+    try {
+      return mapper.writeValueAsString(checkpoint);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static CompletableFuture<GetTableMetricsCheckpointResponse> okCheckpoint(
+      String tableId, String checkpointJson) {
+    return completed(
+        GetTableMetricsCheckpointResponse.builder()
+            .checkpoints(
+                Collections.singletonList(
+                    GetTableMetricsCheckpointResponse.TableMetadataCheckpoint.builder()
+                        .tableId(tableId)
+                        .checkpoint(checkpointJson)
+                        .build()))
+            .build());
+  }
+
+  private static CompletableFuture<InitializeTableMetricsCheckpointResponse> initOk() {
+    return completed(InitializeTableMetricsCheckpointResponse.builder().build());
+  }
+
+  private static CompletableFuture<UpsertTableMetricsCheckpointResponse> upsertOk() {
+    return completed(UpsertTableMetricsCheckpointResponse.builder().build());
+  }
+
+  /** Stubs generate-url (one presigned URL) + a successful presigned PUT. */
+  private void stubGenerateUpload() {
+    when(apiClient.generateCommitMetadataUploadUrl(any()))
+        .thenReturn(
+            completed(
+                GenerateCommitMetadataUploadUrlResponse.builder()
+                    .uploadUrls(Collections.singletonList("https://presigned"))
+                    .build()));
+    when(uploader.uploadFileToPresignedUrl(anyString(), anyString(), anyInt()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+  }
+
+  /** Stubs the full happy-path: list metadata/, generate url, upload, upsert. */
+  private void stubFullUpload(List<File> metadataListing) {
+    when(storageClient.listAllFilesInDir(metadataDir)).thenReturn(completed(metadataListing));
+    stubGenerateUpload();
+    when(apiClient.upsertTableMetricsCheckpoint(any())).thenReturn(upsertOk());
+  }
+
+  private static GenerateCommitMetadataUploadUrlRequest argThatCommitInstantIs(String filename) {
+    return ArgumentMatchers.argThat(
+        req -> req != null && req.getCommitInstants().contains(filename));
+  }
+
+  private static <T> CompletableFuture<T> completed(T value) {
+    return CompletableFuture.completedFuture(value);
+  }
+
+  private static <T> CompletableFuture<T> failedFuture(Throwable error) {
+    CompletableFuture<T> future = new CompletableFuture<>();
+    future.completeExceptionally(error);
+    return future;
+  }
+
+  private static <T extends ApiResponse> CompletableFuture<T> failed(
+      T response, int statusCode, String cause) {
+    response.setError(statusCode, cause);
+    return CompletableFuture.completedFuture(response);
+  }
+
+  private static File jsonFile(String name) {
+    return File.builder().filename(name).isDirectory(false).lastModifiedAt(Instant.EPOCH).build();
+  }
+}

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergMetadataUploaderService.java
@@ -76,9 +76,7 @@ class TestIcebergMetadataUploaderService {
             storageClient, apiClient, uploader, storageUtils, metrics);
   }
 
-  // ---------------------------------------------------------------------------
-  // uploadInstantsInTables / aggregation
-  // ---------------------------------------------------------------------------
+  /* uploadInstantsInTables / aggregation */
 
   @Test
   void emptyTableSetCompletesTrueWithoutApiCalls() {
@@ -102,9 +100,7 @@ class TestIcebergMetadataUploaderService {
     assertFalse(service.uploadInstantsInTables(ImmutableSet.of(ok, bad)).join());
   }
 
-  // ---------------------------------------------------------------------------
-  // checkpoint fetch / parse
-  // ---------------------------------------------------------------------------
+  /* checkpoint fetch / parse */
 
   @Test
   void checkpointFetchFailureReturnsFalseAndIncrementsMetric() {
@@ -142,9 +138,7 @@ class TestIcebergMetadataUploaderService {
         .initializeTableMetricsCheckpoint(any(InitializeTableMetricsCheckpointRequest.class));
   }
 
-  // ---------------------------------------------------------------------------
-  // initialise path
-  // ---------------------------------------------------------------------------
+  /* initialise path */
 
   @Test
   void noCheckpointInitialisesThenUploads() {
@@ -172,9 +166,7 @@ class TestIcebergMetadataUploaderService {
     verify(apiClient, never()).generateCommitMetadataUploadUrl(any());
   }
 
-  // ---------------------------------------------------------------------------
-  // fallback listing path
-  // ---------------------------------------------------------------------------
+  /* fallback listing path */
 
   @Test
   void fallbackUpToDateIsNoOp() {
@@ -214,9 +206,7 @@ class TestIcebergMetadataUploaderService {
             eq(MetricsConstants.MetadataUploadFailureReasons.NO_SUCH_KEY), anyString());
   }
 
-  // ---------------------------------------------------------------------------
-  // version-hint.text resolution
-  // ---------------------------------------------------------------------------
+  /* version-hint.text resolution */
 
   @Test
   void versionHintResolvesTargetAndUploads() {
@@ -260,9 +250,7 @@ class TestIcebergMetadataUploaderService {
     verify(apiClient).generateCommitMetadataUploadUrl(argThatCommitInstantIs("v6.metadata.json"));
   }
 
-  // ---------------------------------------------------------------------------
-  // metadataLocationHint fast path
-  // ---------------------------------------------------------------------------
+  /* metadataLocationHint fast path */
 
   @Test
   void hintPathUpToDateSkipsListing() {
@@ -289,9 +277,7 @@ class TestIcebergMetadataUploaderService {
     verify(apiClient).generateCommitMetadataUploadUrl(argThatCommitInstantIs("v9.metadata.json"));
   }
 
-  // ---------------------------------------------------------------------------
-  // upload / upsert failure branches
-  // ---------------------------------------------------------------------------
+  /* upload / upsert failure branches */
 
   @Test
   void presignedUrlFailureReturnsFalse() {
@@ -327,9 +313,7 @@ class TestIcebergMetadataUploaderService {
             eq(MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_SYSTEM_ERROR), anyString());
   }
 
-  // ===========================================================================
-  // Static helper tests (pure, no mocks)
-  // ===========================================================================
+  /* Static helper tests (pure, no mocks) */
 
   @Test
   void picksLatestHiveGlueStyleMetadataJsonByNumericPrefix() {
@@ -436,9 +420,7 @@ class TestIcebergMetadataUploaderService {
     assertEquals("filename.json", IcebergMetadataUploaderService.lastPathSegment("filename.json"));
   }
 
-  // ===========================================================================
-  // helpers
-  // ===========================================================================
+  /* helpers */
 
   private static Set<Table> singleton(Table t) {
     return Collections.singleton(t);

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
@@ -1,0 +1,105 @@
+package ai.onehouse.metadata_extractor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ai.onehouse.api.models.request.TableFormat;
+import ai.onehouse.storage.AsyncStorageClient;
+import ai.onehouse.storage.StorageUtils;
+import ai.onehouse.storage.models.File;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TestIcebergTableFormatDetector {
+  private static final String TABLE_PATH = "s3://bucket/db/t";
+  private static final String METADATA_PATH = "s3://bucket/db/t/metadata";
+
+  @Mock private AsyncStorageClient asyncStorageClient;
+  private IcebergTableFormatDetector detector;
+
+  @BeforeEach
+  void setUp() {
+    detector = new IcebergTableFormatDetector(asyncStorageClient, new StorageUtils());
+  }
+
+  @Test
+  void declaresIcebergFormat() {
+    assertEquals(TableFormat.ICEBERG, detector.format());
+  }
+
+  @Test
+  void matchesWhenMetadataDirHasMetadataJson() {
+    when(asyncStorageClient.listAllFilesInDir(METADATA_PATH))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(
+                    file("v3.metadata.json", false),
+                    file("snap-1.avro", false))));
+    assertTrue(
+        detector
+            .matches(TABLE_PATH, Arrays.asList(file("metadata", true), file("data", true)))
+            .join());
+  }
+
+  @Test
+  void doesNotMatchWhenMetadataDirEmptyOfMetadataJson() {
+    // Real false-positive: a folder happens to have a `metadata/` subdir but no Iceberg pointer.
+    when(asyncStorageClient.listAllFilesInDir(METADATA_PATH))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Arrays.asList(file("schema.csv", false), file("README.md", false))));
+    assertFalse(
+        detector
+            .matches(TABLE_PATH, Arrays.asList(file("metadata", true), file("data", true)))
+            .join());
+  }
+
+  @Test
+  void doesNotMatchOnFileNamedMetadata() {
+    // A non-directory entry named "metadata" must not be confused with the metadata/ folder, and
+    // we must not issue the validating LIST when the marker isn't present.
+    assertFalse(
+        detector.matches(TABLE_PATH, Collections.singletonList(file("metadata", false))).join());
+    verify(asyncStorageClient, never()).listAllFilesInDir(METADATA_PATH);
+  }
+
+  @Test
+  void doesNotMatchOnHudiLayout() {
+    assertFalse(
+        detector
+            .matches(TABLE_PATH, Arrays.asList(file(".hoodie", true), file("part-0.parquet", false)))
+            .join());
+    verify(asyncStorageClient, never()).listAllFilesInDir(METADATA_PATH);
+  }
+
+  @Test
+  void matchesWhenMetadataDirEntryHasTrailingSlash() {
+    // S3 ListObjectsV2 returns CommonPrefixes as e.g. "metadata/" (with the trailing slash that
+    // S3 itself uses). The storage client may surface that filename verbatim, so the detector
+    // must accept both "metadata" and "metadata/" as the folder marker.
+    when(asyncStorageClient.listAllFilesInDir(METADATA_PATH))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Collections.singletonList(file("00000-uuid.metadata.json", false))));
+    assertTrue(
+        detector
+            .matches(TABLE_PATH, Collections.singletonList(file("metadata/", true)))
+            .join());
+  }
+
+  private static File file(String name, boolean dir) {
+    return File.builder().filename(name).isDirectory(dir).lastModifiedAt(Instant.EPOCH).build();
+  }
+}

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TestIcebergTableFormatDetector.java
@@ -68,8 +68,10 @@ class TestIcebergTableFormatDetector {
 
   @Test
   void doesNotMatchOnFileNamedMetadata() {
-    // A non-directory entry named "metadata" must not be confused with the metadata/ folder, and
-    // we must not issue the validating LIST when the marker isn't present.
+    /*
+     * A non-directory entry named "metadata" must not be confused with the metadata/ folder, and
+     * we must not issue the validating LIST when the marker isn't present.
+     */
     assertFalse(
         detector.matches(TABLE_PATH, Collections.singletonList(file("metadata", false))).join());
     verify(asyncStorageClient, never()).listAllFilesInDir(METADATA_PATH);
@@ -86,9 +88,11 @@ class TestIcebergTableFormatDetector {
 
   @Test
   void matchesWhenMetadataDirEntryHasTrailingSlash() {
-    // S3 ListObjectsV2 returns CommonPrefixes as e.g. "metadata/" (with the trailing slash that
-    // S3 itself uses). The storage client may surface that filename verbatim, so the detector
-    // must accept both "metadata" and "metadata/" as the folder marker.
+    /*
+     * S3 ListObjectsV2 returns CommonPrefixes as e.g. "metadata/" (with the trailing slash that
+     * S3 itself uses). The storage client may surface that filename verbatim, so the detector
+     * must accept both "metadata" and "metadata/" as the folder marker.
+     */
     when(asyncStorageClient.listAllFilesInDir(METADATA_PATH))
         .thenReturn(
             CompletableFuture.completedFuture(

--- a/lakeview/src/test/java/ai/onehouse/storage/StorageUtilsTest.java
+++ b/lakeview/src/test/java/ai/onehouse/storage/StorageUtilsTest.java
@@ -10,6 +10,9 @@ class StorageUtilsTest {
   @Test
   void testGetPathFromUrl() {
     assertEquals("path/to/file", storageUtils.getPathFromUrl("s3://bucket/path/to/file"));
+    // s3a:// is the Hadoop scheme used by the iceberg/Glue metadata_location values the agent
+    // writes into Firestore — IcebergMetadataUploaderService must be able to parse these.
+    assertEquals("path/to/file", storageUtils.getPathFromUrl("s3a://bucket/path/to/file"));
     assertEquals("path/to/file", storageUtils.getPathFromUrl("gs://bucket/path/to/file"));
     assertEquals(
         "path/to/file",
@@ -24,6 +27,7 @@ class StorageUtilsTest {
         storageUtils.getPathFromUrl(
             "abfss://container@account.dfs.core.windows.net/path/to/file"));
     assertEquals("", storageUtils.getPathFromUrl("s3://bucket"));
+    assertEquals("", storageUtils.getPathFromUrl("s3a://bucket"));
     assertEquals("", storageUtils.getPathFromUrl("gs://bucket"));
     assertEquals(
         "", storageUtils.getPathFromUrl("https://account.blob.core.windows.net/container"));
@@ -110,6 +114,9 @@ class StorageUtilsTest {
   @Test
   void testGetBucketNameFromUri() {
     assertEquals("bucket", storageUtils.getBucketNameFromUri("s3://bucket/path/to/file"));
+    // s3a:// must resolve to the same bucket as s3:// — IcebergMetadataUploaderService passes
+    // the s3a:// metadata_location verbatim through this method.
+    assertEquals("bucket", storageUtils.getBucketNameFromUri("s3a://bucket/path/to/file"));
     assertEquals("bucket", storageUtils.getBucketNameFromUri("gs://bucket/path/to/file"));
     assertEquals(
         "container",
@@ -128,6 +135,7 @@ class StorageUtilsTest {
         storageUtils.getBucketNameFromUri(
             "abfss://container@account.dfs.core.windows.net/path/to/file"));
     assertEquals("bucket", storageUtils.getBucketNameFromUri("s3://bucket"));
+    assertEquals("bucket", storageUtils.getBucketNameFromUri("s3a://bucket"));
     assertEquals("bucket", storageUtils.getBucketNameFromUri("gs://bucket"));
     assertEquals(
         "container",

--- a/lakeview/src/test/java/ai/onehouse/storage/StorageUtilsTest.java
+++ b/lakeview/src/test/java/ai/onehouse/storage/StorageUtilsTest.java
@@ -10,8 +10,10 @@ class StorageUtilsTest {
   @Test
   void testGetPathFromUrl() {
     assertEquals("path/to/file", storageUtils.getPathFromUrl("s3://bucket/path/to/file"));
-    // s3a:// is the Hadoop scheme used by the iceberg/Glue metadata_location values the agent
-    // writes into Firestore — IcebergMetadataUploaderService must be able to parse these.
+    /*
+     * s3a:// is the Hadoop scheme used by the iceberg/Glue metadata_location values the agent
+     * writes into Firestore — IcebergMetadataUploaderService must be able to parse these.
+     */
     assertEquals("path/to/file", storageUtils.getPathFromUrl("s3a://bucket/path/to/file"));
     assertEquals("path/to/file", storageUtils.getPathFromUrl("gs://bucket/path/to/file"));
     assertEquals(
@@ -114,8 +116,10 @@ class StorageUtilsTest {
   @Test
   void testGetBucketNameFromUri() {
     assertEquals("bucket", storageUtils.getBucketNameFromUri("s3://bucket/path/to/file"));
-    // s3a:// must resolve to the same bucket as s3:// — IcebergMetadataUploaderService passes
-    // the s3a:// metadata_location verbatim through this method.
+    /*
+     * s3a:// must resolve to the same bucket as s3:// — IcebergMetadataUploaderService passes
+     * the s3a:// metadata_location verbatim through this method.
+     */
     assertEquals("bucket", storageUtils.getBucketNameFromUri("s3a://bucket/path/to/file"));
     assertEquals("bucket", storageUtils.getBucketNameFromUri("gs://bucket/path/to/file"));
     assertEquals(


### PR DESCRIPTION
## Summary

Sub-PR 2 of 2 splitting #189. Layers the Iceberg detector + uploader on top of the `TableFormatDetector` SPI introduced in #190 (already merged). The control plane parses the snapshot summary from each uploaded `metadata.json` — cumulative `total-records`, `total-files-size`, `total-data-files`, per-snapshot deltas, and the `snapshot-log[]` history — gateway-controller side is a separate PR.

See [`docs/iceberg-support.md`](docs/iceberg-support.md) for the full design.

## What changed

**Discovery**
- `IcebergTableFormatDetector`: matches a directory if it contains a `metadata/` sub-dir AND that sub-dir holds a `*.metadata.json` pointer (so Spark checkpoint dirs / doc folders named `metadata/` don't false-positive). Registered alongside `HudiTableFormatDetector` in the `TableDiscoveryService` detector map.
- `Database` gains an optional `tableHints` map keyed on the `#tableId` segment of `basePaths`; entries carry a `metadataLocationHint` that the control plane supplies when it knows the current `metadata.json` URI (e.g. AWS Glue `metadata_location`). Hint-less tables fall back to plain discovery.
- `Table` model gains `tableFormat` (defaults to HUDI for backward compat) and `metadataLocationHint`.

**Upload**
- `IcebergMetadataUploaderService` as sibling of `TableMetadataUploaderService`. Hudi's active/archived timeline distinction, `hoodie.properties` bootstrap, and LSM manifest plumbing don't apply, so a separate service is clearer than a branching megaclass. Reuses `OnehouseApiClient`, `PresignedUrlFileUploader`, `AsyncStorageClient`, `StorageUtils`.
- Pointer-file selection (preference order):
  1. `metadataLocationHint` from parser YAML (catalog-driven, e.g. Glue `metadata_location`)
  2. `metadata/version-hint.text` (Hadoop catalog) — integer content names the current `v{N}.metadata.json` unambiguously
  3. Numeric-aware filename comparison — leading integer (after optional `v` prefix) is the version number; works for both `v{N}.metadata.json` (Hadoop) and `00000-<uuid>.metadata.json` (Hive/Glue/Spark)
- `TableDiscoveryAndUploadJob.dispatchUpload` partitions discovered tables by format and runs the two uploaders concurrently; both `runOnce` and `processTables` route through it.

**Wire**
- `TableFormat` (added in #190) now flows through to `InitializeSingleTableMetricsCheckpointRequest.tableFormat` (nullable; server treats absent as HUDI). `TableType` (COW/MOR) stays `@NonNull` to preserve the existing wire contract; Iceberg init passes `COW` as a meaningless placeholder since the server discriminates on `tableFormat` first.
- `OBJECT_STORAGE_URI_PATTERN` accepts `s3a://` alongside `s3://` (Glue `metadata_location` scheme).

## Hudi safety

| Check | Status |
|---|---|
| `Database.tableFormat` null → HUDI fallback | ✅ (from #190) |
| `Table.tableFormat` `@Builder.Default = HUDI` | ✅ |
| `dispatchUpload` null-tableFormat → HUDI bucket | ✅ |
| `TableMetadataUploaderService` (Hudi path) untouched | ✅ |
| `OBJECT_STORAGE_URI_PATTERN` widening — `s3://`, `gs://`, `abfss://`, Azure HTTPS all still match (verified with 13-case regex sanity check) | ✅ |
| Hudi-only YAML: extra cost is one empty-set future per cycle | ✅ negligible |
| Full `./gradlew build` + `./gradlew test` green across all modules | ✅ |

## Deployment ordering ⚠️

This change spans three repos and **must roll out in order**:

1. **idls** — `TableFormat` proto enum / `TableMetricsCheckpoint` field
2. **gateway-controller** — `IcebergCommitMetadataParser` parses the uploaded `metadata.json` and emits to OpenSearch
3. **LakeView** (this PR)

If LakeView ships before the server understands `tableFormat`, the server-side protobuf JSON parser drops the unknown enum value and persists `TABLE_FORMAT_INVALID`, routing Iceberg uploads through the Hudi back-compat fallback. **Do not deploy this until the running control plane tolerates `tableFormat=ICEBERG` cleanly.** See [`docs/iceberg-support.md`](docs/iceberg-support.md).

## Test plan

- [x] `./gradlew :lakeview:test` green (full suite)
- [x] New `TestIcebergMetadataUploaderService` (~538 lines) covers all three pointer-resolution paths + upload + checkpoint flows
- [x] New `TestIcebergTableFormatDetector` covers match / no-match / false-positive (`metadata/` without `*.metadata.json`) / Hudi-layout-rejection / trailing-slash CommonPrefix
- [x] Existing `TableDiscoveryServiceTest` extended with `testDiscoverIcebergTableByDeclaredFormat`
- [x] `TableDiscoveryAndUploadJobTest` covers `dispatchUpload` routing
- [x] `StorageUtilsTest` covers `s3a://` for `getPathFromUrl` + `getBucketNameFromUri`
- [x] `./gradlew build` green across all modules (lakeview, lakeview-glue, lakeview-sync-tool)
- [x] CI green
- [x] Manual: end-to-end against a real Glue iceberg table once control-plane parser lands

## Related
- Sub-PR 1 (merged): #190 — TableFormatDetector SPI scaffold
- Original combined PR: #189 (will be closed after this lands)