### PR TITLE
[ENG-43320] Fix InputStream leak in PresignedUrlFileUploader + error-path tests

### DIFF
--- a/lakeview/src/main/java/ai/onehouse/storage/PresignedUrlFileUploader.java
+++ b/lakeview/src/main/java/ai/onehouse/storage/PresignedUrlFileUploader.java
@@ -78,8 +78,8 @@ public class PresignedUrlFileUploader {
     if (fileStreamData.getFileSize() <= fileUploadStreamBatchSize) {
       // if the file size is less than the stream batch size, upload it directly
       RequestBody requestBody;
-      try {
-        requestBody = RequestBody.create(mediaType, IOUtils.toByteArray(fileStreamData.getInputStream()));
+      try (InputStream is = fileStreamData.getInputStream()) {
+        requestBody = RequestBody.create(mediaType, IOUtils.toByteArray(is));
         request = new Request.Builder().url(presignedUrl).put(requestBody).build();
       } catch (IOException e) {
         throw new FileUploadException(e);

--- a/lakeview/src/test/java/ai/onehouse/storage/PresignedUrlFileUploaderTest.java
+++ b/lakeview/src/test/java/ai/onehouse/storage/PresignedUrlFileUploaderTest.java
@@ -2,18 +2,22 @@ package ai.onehouse.storage;
 
 import static ai.onehouse.constants.MetadataExtractorConstants.DEFAULT_FILE_UPLOAD_STREAM_BATCH_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import ai.onehouse.api.AsyncHttpClientWithRetry;
 import ai.onehouse.constants.MetricsConstants;
+import ai.onehouse.exceptions.FileUploadException;
 import ai.onehouse.metrics.LakeViewExtractorMetrics;
 import ai.onehouse.storage.models.FileStreamData;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -50,7 +54,7 @@ class PresignedUrlFileUploaderTest {
   @Mock private LakeViewExtractorMetrics hudiMetadataExtractorMetrics;
   private final String fileContent = "some-file-content";
   private final InputStream inputStream =
-      IOUtils.toInputStream(fileContent, StandardCharsets.UTF_8);
+      spy(IOUtils.toInputStream(fileContent, StandardCharsets.UTF_8));
   private MockWebServer mockWebServer;
 
   private static final int FAILURE_STATUS_CODE = 500;
@@ -60,13 +64,13 @@ class PresignedUrlFileUploaderTest {
   @BeforeEach
   void setup() {
     mockWebServer = new MockWebServer();
+  }
+
+  private void stubStreamFile(InputStream is, long size) {
     when(mockAsyncStorageClient.streamFileAsync(FILE_URI))
         .thenReturn(
             CompletableFuture.completedFuture(
-                FileStreamData.builder()
-                    .inputStream(inputStream)
-                    .fileSize(fileContent.length())
-                    .build()));
+                FileStreamData.builder().inputStream(is).fileSize(size).build()));
   }
 
   @SneakyThrows
@@ -94,6 +98,7 @@ class PresignedUrlFileUploaderTest {
   @Test
   void testUploadFileToPresignedUrl() {
     setupMockWebServer(false);
+    stubStreamFile(inputStream, fileContent.length());
 
     PresignedUrlFileUploader uploader =
         new PresignedUrlFileUploader(
@@ -113,6 +118,7 @@ class PresignedUrlFileUploaderTest {
   @Test
   void testUploadFileToPresignedUrlFailure() {
     setupMockWebServer(true);
+    stubStreamFile(inputStream, fileContent.length());
 
     PresignedUrlFileUploader uploader =
         new PresignedUrlFileUploader(
@@ -143,6 +149,7 @@ class PresignedUrlFileUploaderTest {
   @Test
   void testUploadLargeFile() {
     setupMockWebServer(false);
+    stubStreamFile(inputStream, fileContent.length());
 
     PresignedUrlFileUploader uploader =
         new PresignedUrlFileUploader(
@@ -154,6 +161,103 @@ class PresignedUrlFileUploaderTest {
 
     verify(mockAsyncStorageClient).streamFileAsync(FILE_URI);
     verifyRequestPayload();
+  }
+
+  @Test
+  @SneakyThrows
+  void testUploadFileToPresignedUrl_smallFileClosesInputStreamOnSuccess() {
+    setupMockWebServer(false);
+    stubStreamFile(inputStream, fileContent.length());
+
+    PresignedUrlFileUploader uploader =
+        new PresignedUrlFileUploader(
+            mockAsyncStorageClient, asyncHttpClientWithRetry, hudiMetadataExtractorMetrics);
+
+    uploader
+        .uploadFileToPresignedUrl(
+            mockWebServer.url("/upload").url().toString(),
+            FILE_URI,
+            DEFAULT_FILE_UPLOAD_STREAM_BATCH_SIZE)
+        .join();
+
+    verify(inputStream).close();
+  }
+
+  @Test
+  @SneakyThrows
+  void testUploadFileToPresignedUrl_smallFileClosesInputStreamOnReadFailure() {
+    setupMockWebServer(false);
+    IOException simulatedError = new IOException("simulated read failure");
+    InputStream throwingStream =
+        spy(
+            new InputStream() {
+              @Override
+              public int read() throws IOException {
+                throw simulatedError;
+              }
+
+              @Override
+              public int read(byte[] b, int off, int len) throws IOException {
+                throw simulatedError;
+              }
+            });
+    stubStreamFile(throwingStream, fileContent.length());
+
+    PresignedUrlFileUploader uploader =
+        new PresignedUrlFileUploader(
+            mockAsyncStorageClient, asyncHttpClientWithRetry, hudiMetadataExtractorMetrics);
+
+    CompletionException thrown =
+        assertThrows(
+            CompletionException.class,
+            () ->
+                uploader
+                    .uploadFileToPresignedUrl(
+                        mockWebServer.url("/upload").url().toString(),
+                        FILE_URI,
+                        DEFAULT_FILE_UPLOAD_STREAM_BATCH_SIZE)
+                    .join());
+
+    assertInstanceOf(FileUploadException.class, thrown.getCause());
+    assertSame(simulatedError, thrown.getCause().getCause());
+    verify(throwingStream).close();
+  }
+
+  @Test
+  @SneakyThrows
+  void testUploadFileToPresignedUrl_acceptable4xxNotRetried() {
+    mockWebServer.setDispatcher(
+        new Dispatcher() {
+          @Override
+          public @NotNull MockResponse dispatch(@NotNull RecordedRequest req) {
+            return new MockResponse().setBody("forbidden").setResponseCode(403);
+          }
+        });
+    mockWebServer.start();
+    stubStreamFile(inputStream, fileContent.length());
+
+    AsyncHttpClientWithRetry retryingClient = new AsyncHttpClientWithRetry(3, 50L, client);
+    PresignedUrlFileUploader uploader =
+        new PresignedUrlFileUploader(
+            mockAsyncStorageClient, retryingClient, hudiMetadataExtractorMetrics);
+
+    ExecutionException thrown =
+        assertThrows(
+            ExecutionException.class,
+            () ->
+                uploader
+                    .uploadFileToPresignedUrl(
+                        mockWebServer.url("/upload").url().toString(),
+                        FILE_URI,
+                        DEFAULT_FILE_UPLOAD_STREAM_BATCH_SIZE)
+                    .get());
+
+    assertInstanceOf(FileUploadException.class, thrown.getCause());
+    assertEquals(
+        1, mockWebServer.getRequestCount(), "acceptable 4xx status should not trigger retry");
+    verify(hudiMetadataExtractorMetrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            any(MetricsConstants.MetadataUploadFailureReasons.class), anyString());
   }
 
   @SneakyThrows


### PR DESCRIPTION
## Summary

The small-file branch of `PresignedUrlFileUploader#getRequest` called `IOUtils.toByteArray(fileStreamData.getInputStream())` without closing the stream, leaking file descriptors / underlying HTTP connections from S3/GCS/Azure SDKs on every upload. The large-file streaming branch already does it right via try-with-resources — this PR aligns the small-file branch.

Then adds the missing error-path tests (the existing class only covered happy, 5xx-failure, and large-file paths — 3 tests / 177 LOC).

### Code change (`PresignedUrlFileUploader.java`)

Before:
```java
if (fileStreamData.getFileSize() <= fileUploadStreamBatchSize) {
  RequestBody requestBody;
  try {
    requestBody = RequestBody.create(mediaType, IOUtils.toByteArray(fileStreamData.getInputStream()));
    request = new Request.Builder().url(presignedUrl).put(requestBody).build();
  } catch (IOException e) {
    throw new FileUploadException(e);
  }
}
```

After:
```java
if (fileStreamData.getFileSize() <= fileUploadStreamBatchSize) {
  RequestBody requestBody;
  try (InputStream is = fileStreamData.getInputStream()) {
    requestBody = RequestBody.create(mediaType, IOUtils.toByteArray(is));
    request = new Request.Builder().url(presignedUrl).put(requestBody).build();
  } catch (IOException e) {
    throw new FileUploadException(e);
  }
}
```

### Tests added (`PresignedUrlFileUploaderTest.java`)

1. `testUploadFileToPresignedUrl_smallFileClosesInputStreamOnSuccess` — wraps the test `InputStream` in a Mockito spy and asserts `verify(inputStream).close()` after a successful upload.
2. `testUploadFileToPresignedUrl_smallFileClosesInputStreamOnReadFailure` — uses an `InputStream` whose `read(...)` throws `IOException`; asserts the wrapped `FileUploadException` surfaces with the original `IOException` cause AND that `close()` was still called.
3. `testUploadFileToPresignedUrl_acceptable4xxNotRetried` — `MockWebServer` returns 403 (acceptable failure code per `ACCEPTABLE_HTTP_FAILURE_STATUS_CODES`); asserts `getRequestCount() == 1` to prove retry was skipped even with `maxRetries=3`, AND that the failure metric is emitted.

Refactored `@BeforeEach` to move the `streamFileAsync` stub into a `stubStreamFile(InputStream, long)` helper so the new error-path tests can supply their own `InputStream` without tripping strict-stubbing on the existing 3 tests.

## Why this matters

- Long-running data-plane extractor pods leak file descriptors over time on every small-file upload — eventually `Too many open files` if the leak compounds against the S3/GCS/Azure SDK's internal HTTP connection pool.
- The retry path on the acceptable-4xx code was untested. A future regression that fails to short-circuit on `ACCEPTABLE_HTTP_FAILURE_STATUS_CODES` would silently inflate API spend (3× requests for every expired/invalid pre-signed URL).

## Regression risk

Zero. The only behavior change in the production code is that the `InputStream` from the small-file path now closes after the byte buffer is materialised. Nothing else uses the `InputStream` after `getRequest` returns — `IOUtils.toByteArray` has already drained it into a `byte[]` that backs the `RequestBody`. The streaming large-file path is unchanged.

## Test plan

- [x] `./gradlew :lakeview:test --tests PresignedUrlFileUploaderTest` — all 6 tests green (3 existing + 3 new) locally.
- [x] `./gradlew :lakeview:test --tests "ai.onehouse.storage.*"` — full storage package green.
- [x] `./gradlew :lakeview:spotlessCheck` — green.
- [ ] CI: build, sonar, coverage gates.

Background code-flow doc for the metadata-extractor data-plane Push-Model job lives at [`10XEngineer/docs/lakeview-metadata-extractor-flow.md`](https://github.com/onehouseinc/10XEngineer/blob/main/docs/lakeview-metadata-extractor-flow.md) (just merged).