### PR TITLE
[AUTOMATION TESTING] [AUDIT-5891] Updating release tag to release-v0.31.0

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: onehouse/lake-view
   pullPolicy: Always
   # Release version to use
-  tag: release-v0.15.0
+  tag: release-v0.31.0
 
 # Config yaml to be provided to the extractor. Refer to readme for the format of the config file
 # not required if config path is being provided


### PR DESCRIPTION
Auto-generated by the Lakeview rollout automation. Bumps `image.tag` in `helm-chart/values.yaml` to `release-v0.31.0`. Audit: AUDIT-5891.