### PR TITLE
[ENG-44755] Emit discovery_path label on lakeView_table_discovery_failure

### DIFF
--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableDiscoveryService.java
@@ -247,7 +247,8 @@ public class TableDiscoveryService {
                 log.error("Failed to discover tables in path: {}", path, e);
                 lakeviewExtractorMetrics.incrementTableDiscoveryFailureCounter(
                     getMetadataExtractorFailureReason(
-                        e, MetricsConstants.MetadataUploadFailureReasons.UNKNOWN));
+                        e, MetricsConstants.MetadataUploadFailureReasons.UNKNOWN),
+                    path);
                 return emptySet();
               });
     } catch (Exception e) {

--- a/lakeview/src/main/java/ai/onehouse/metrics/LakeViewExtractorMetrics.java
+++ b/lakeview/src/main/java/ai/onehouse/metrics/LakeViewExtractorMetrics.java
@@ -27,11 +27,14 @@ public class LakeViewExtractorMetrics {
   static final String EXTRACTOR_JOB_RUN_MODE_TAG_KEY = "extractor_job_run_mode";
   static final String METADATA_UPLOAD_FAILURE_REASON_TAG_KEY = "metadata_upload_failure_reason";
   static final String METADATA_DISCOVER_FAILURE_REASON_TAG_KEY = "metadata_discover_failure_reason";
-  static final String TABLE_BASE_PATH_TAG_KEY = "table_base_path";
+  // The failing path from the discovery walk. Named discovery_path (not table_base_path) because
+  // it is the prefix whose listing failed — which may be a table root or, when a Deny lands on a
+  // parent prefix before the walk descends, a container of many tables.
+  static final String DISCOVERY_PATH_TAG_KEY = "discovery_path";
 
   // Sentinel used when a discovery failure is raised above the per-path scan (e.g. a run-level
   // AwsServiceException), so the counter's tag set stays consistent across all call sites.
-  static final String UNKNOWN_TABLE_BASE_PATH = "unknown";
+  static final String UNKNOWN_DISCOVERY_PATH = "unknown";
 
 
   // Metrics
@@ -81,15 +84,15 @@ public class LakeViewExtractorMetrics {
 
   public void incrementTableDiscoveryFailureCounter(
         MetricsConstants.MetadataUploadFailureReasons metadataUploadFailureReasons) {
-    incrementTableDiscoveryFailureCounter(metadataUploadFailureReasons, UNKNOWN_TABLE_BASE_PATH);
+    incrementTableDiscoveryFailureCounter(metadataUploadFailureReasons, UNKNOWN_DISCOVERY_PATH);
   }
 
   public void incrementTableDiscoveryFailureCounter(
         MetricsConstants.MetadataUploadFailureReasons metadataUploadFailureReasons,
-        String tableBasePath) {
+        String discoveryPath) {
     List<Tag> tags = getDefaultTags();
     tags.add(Tag.of(METADATA_DISCOVER_FAILURE_REASON_TAG_KEY, metadataUploadFailureReasons.name()));
-    tags.add(Tag.of(TABLE_BASE_PATH_TAG_KEY, tableBasePath));
+    tags.add(Tag.of(DISCOVERY_PATH_TAG_KEY, discoveryPath));
     metrics.increment(TABLE_DISCOVERY_FAILURE_COUNTER, tags);
   }
 

--- a/lakeview/src/main/java/ai/onehouse/metrics/LakeViewExtractorMetrics.java
+++ b/lakeview/src/main/java/ai/onehouse/metrics/LakeViewExtractorMetrics.java
@@ -27,6 +27,11 @@ public class LakeViewExtractorMetrics {
   static final String EXTRACTOR_JOB_RUN_MODE_TAG_KEY = "extractor_job_run_mode";
   static final String METADATA_UPLOAD_FAILURE_REASON_TAG_KEY = "metadata_upload_failure_reason";
   static final String METADATA_DISCOVER_FAILURE_REASON_TAG_KEY = "metadata_discover_failure_reason";
+  static final String TABLE_BASE_PATH_TAG_KEY = "table_base_path";
+
+  // Sentinel used when a discovery failure is raised above the per-path scan (e.g. a run-level
+  // AwsServiceException), so the counter's tag set stays consistent across all call sites.
+  static final String UNKNOWN_TABLE_BASE_PATH = "unknown";
 
 
   // Metrics
@@ -76,8 +81,15 @@ public class LakeViewExtractorMetrics {
 
   public void incrementTableDiscoveryFailureCounter(
         MetricsConstants.MetadataUploadFailureReasons metadataUploadFailureReasons) {
+    incrementTableDiscoveryFailureCounter(metadataUploadFailureReasons, UNKNOWN_TABLE_BASE_PATH);
+  }
+
+  public void incrementTableDiscoveryFailureCounter(
+        MetricsConstants.MetadataUploadFailureReasons metadataUploadFailureReasons,
+        String tableBasePath) {
     List<Tag> tags = getDefaultTags();
     tags.add(Tag.of(METADATA_DISCOVER_FAILURE_REASON_TAG_KEY, metadataUploadFailureReasons.name()));
+    tags.add(Tag.of(TABLE_BASE_PATH_TAG_KEY, tableBasePath));
     metrics.increment(TABLE_DISCOVERY_FAILURE_COUNTER, tags);
   }
 

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableDiscoveryServiceTest.java
@@ -374,7 +374,7 @@ class TableDiscoveryServiceTest {
     // Verify the mock
     verify(hudiMetadataExtractorMetrics)
             .incrementTableDiscoveryFailureCounter(
-                    MetricsConstants.MetadataUploadFailureReasons.RATE_LIMITING);
+                    MetricsConstants.MetadataUploadFailureReasons.RATE_LIMITING, basePath);
   }
 
   @Test

--- a/lakeview/src/test/java/ai/onehouse/metrics/LakeViewExtractorMetricsTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metrics/LakeViewExtractorMetricsTest.java
@@ -69,6 +69,20 @@ class LakeViewExtractorMetricsTest {
     hudiMetadataExtractorMetrics.incrementTableDiscoveryFailureCounter(reason);
     List<Tag> tags = getDefaultTags();
     tags.add(Tag.of(METADATA_DISCOVER_FAILURE_REASON_TAG_KEY, reason.name()));
+    tags.add(Tag.of(TABLE_BASE_PATH_TAG_KEY, UNKNOWN_TABLE_BASE_PATH));
+    verify(metrics).increment(TABLE_DISCOVERY_FAILURE_COUNTER, tags);
+  }
+
+  @Test
+  void testIncrementTableDiscoveryFailureCounterWithTableBasePath() {
+    MetricsConstants.MetadataUploadFailureReasons reason =
+        MetricsConstants.MetadataUploadFailureReasons.ACCESS_DENIED;
+    String tableBasePath =
+        "s3://dp-datalake-gold-use1-prod/Domain=CustomerOfferEvent/Table=customerofferevent_daily";
+    hudiMetadataExtractorMetrics.incrementTableDiscoveryFailureCounter(reason, tableBasePath);
+    List<Tag> tags = getDefaultTags();
+    tags.add(Tag.of(METADATA_DISCOVER_FAILURE_REASON_TAG_KEY, reason.name()));
+    tags.add(Tag.of(TABLE_BASE_PATH_TAG_KEY, tableBasePath));
     verify(metrics).increment(TABLE_DISCOVERY_FAILURE_COUNTER, tags);
   }
 

--- a/lakeview/src/test/java/ai/onehouse/metrics/LakeViewExtractorMetricsTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metrics/LakeViewExtractorMetricsTest.java
@@ -69,20 +69,20 @@ class LakeViewExtractorMetricsTest {
     hudiMetadataExtractorMetrics.incrementTableDiscoveryFailureCounter(reason);
     List<Tag> tags = getDefaultTags();
     tags.add(Tag.of(METADATA_DISCOVER_FAILURE_REASON_TAG_KEY, reason.name()));
-    tags.add(Tag.of(TABLE_BASE_PATH_TAG_KEY, UNKNOWN_TABLE_BASE_PATH));
+    tags.add(Tag.of(DISCOVERY_PATH_TAG_KEY, UNKNOWN_DISCOVERY_PATH));
     verify(metrics).increment(TABLE_DISCOVERY_FAILURE_COUNTER, tags);
   }
 
   @Test
-  void testIncrementTableDiscoveryFailureCounterWithTableBasePath() {
+  void testIncrementTableDiscoveryFailureCounterWithDiscoveryPath() {
     MetricsConstants.MetadataUploadFailureReasons reason =
         MetricsConstants.MetadataUploadFailureReasons.ACCESS_DENIED;
-    String tableBasePath =
+    String discoveryPath =
         "s3://dp-datalake-gold-use1-prod/Domain=CustomerOfferEvent/Table=customerofferevent_daily";
-    hudiMetadataExtractorMetrics.incrementTableDiscoveryFailureCounter(reason, tableBasePath);
+    hudiMetadataExtractorMetrics.incrementTableDiscoveryFailureCounter(reason, discoveryPath);
     List<Tag> tags = getDefaultTags();
     tags.add(Tag.of(METADATA_DISCOVER_FAILURE_REASON_TAG_KEY, reason.name()));
-    tags.add(Tag.of(TABLE_BASE_PATH_TAG_KEY, tableBasePath));
+    tags.add(Tag.of(DISCOVERY_PATH_TAG_KEY, discoveryPath));
     verify(metrics).increment(TABLE_DISCOVERY_FAILURE_COUNTER, tags);
   }
 


### PR DESCRIPTION
## Summary
`metadataExtractorDiscoveryFailure` fires per-org on `lakeView_table_discovery_failure_total` with **no table-level dimension** — so on-call can only silence the whole org's alert, which then blinds us to any NEW table failure for that org during the silence window. Hit live on [ENG-44423](https://app.clickup.com/t/86e239zk9) / [ENG-44424](https://app.clickup.com/t/86e23a063) (Cardlytics): a customer-side S3 bucket-policy explicit-Deny hit 3 of hundreds of paths under `Domain=CustomerOfferEvent/`, and the only lever was an org-wide 2-week Alertmanager silence.

## Fix
- Add a `table_base_path` tag to `lakeView_table_discovery_failure`, wired at `TableDiscoveryService` — the per-path `.exceptionally` is the only failure call site with the failing path in scope.
- Run-level failure sites (`Main`, `TableDiscoveryAndUploadJob`) route through the reason-only overload, which now supplies an `"unknown"` sentinel so the counter's **tag set stays consistent** across all call sites (needed for a clean Prometheus label family).
- Once emitted, an Alertmanager silence can target `{orgId, table_base_path}` instead of the whole org.

`tableId` is deliberately **not** used: discovery is the step that resolves a path *into* a tableId, so at discovery-failure time no tableId exists yet — the failing base path is the available table-level dimension (matches the ticket's "and/or table base path").

## Follow-ups (not in this PR)
- infra: surface `{{ $labels.table_base_path }}` on the `metadataExtractorDiscoveryFailure` alert + update the runbook silence step to `{orgId, table_base_path}`.
- Cardinality: `table_base_path` is emitted only on failure (0 series in steady state) and is naturally bounded by the customer's Deny scope. A defensive per-round cap (collapse to `__many__` above K distinct failing paths) is a candidate hardening if a wholesale-denial pathological case shows up — open for reviewer input.

## Test plan
- [x] `LakeViewExtractorMetricsTest`: reason-only cases now assert the `"unknown"` sentinel tag; new `testIncrementTableDiscoveryFailureCounterWithTableBasePath` asserts the real path tag.
- [x] `TableDiscoveryServiceTest.testTableDiscoveryEncountersRateLimitException` updated to the path-aware signature.
- [x] `./gradlew :lakeview:spotlessApply` — clean, no rewrites
- [x] `./gradlew :lakeview:test --tests LakeViewExtractorMetricsTest --tests TableDiscoveryServiceTest` — all passed locally

## References
- ClickUp: [ENG-44755](https://app.clickup.com/t/86e26bdn9)
- Source incidents: [ENG-44423](https://app.clickup.com/t/86e239zk9) / [ENG-44424](https://app.clickup.com/t/86e23a063)

🤖 Generated with [Claude Code](https://claude.com/claude-code)