### PR TITLE
[ENG-45879] Classify control-plane "table is deleted" as a skip, not an API failure

### DIFF
--- a/lakeview/src/main/java/ai/onehouse/constants/MetricsConstants.java
+++ b/lakeview/src/main/java/ai/onehouse/constants/MetricsConstants.java
@@ -20,4 +20,15 @@ public class MetricsConstants {
     NO_SUCH_KEY,
     UNKNOWN,
   }
+
+  /**
+   * Why a table was intentionally skipped for a cycle. These are expected, non-error outcomes and
+   * are deliberately kept out of {@link MetadataUploadFailureReasons} so that the
+   * {@code lakeView_table_metadata_processing_failure} counter keeps meaning "something went
+   * wrong".
+   */
+  public enum TableSkipReasons {
+    /** The control plane reports the table as deleted, so there is nothing to upload for it. */
+    DELETED,
+  }
 }

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/MetadataExtractorUtils.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/MetadataExtractorUtils.java
@@ -5,9 +5,50 @@ import ai.onehouse.exceptions.AccessDeniedException;
 import ai.onehouse.exceptions.NoSuchKeyException;
 import ai.onehouse.exceptions.RateLimitException;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
 public final class MetadataExtractorUtils {
 
+    /**
+     * Markers identifying the control plane's "this table is deleted, skip it" advisory, returned
+     * as a per-table {@code error} string on an otherwise successful (HTTP 200)
+     * initialize-tables response.
+     *
+     * <p>Matched on message text because
+     * {@code InitializeTableMetricsCheckpointResponse.InitializeSingleTableMetricsCheckpointResponse}
+     * carries only a free-text {@code error} field — there is no structured error/status code to
+     * switch on. Replace this with a code check as soon as the API exposes one; see
+     * {@link #isTableDeletedError(String)}.
+     */
+    private static final List<String> TABLE_DELETED_ERROR_MARKERS =
+        Collections.unmodifiableList(
+            Arrays.asList("skipped as it is deleted", "table is deleted"));
+
     private MetadataExtractorUtils(){}
+
+    /**
+     * Whether a per-table {@code error} from the initialize-tables response is the control plane's
+     * benign "table has been deleted" advisory rather than an actual failure.
+     *
+     * <p>The control plane returns this on a <b>successful</b> response once a table has been
+     * deleted control-plane side. It means "there is nothing to upload for this table", not "the
+     * call failed" — so callers should skip the table quietly instead of counting an upload
+     * failure. Treating it as a failure produces one ERROR log and one failure-counter increment
+     * per deleted table per cycle, which on a large lake buries real problems (ENG-45879).
+     *
+     * @param error the per-table {@code error} string; may be {@code null} or blank
+     * @return {@code true} if the error denotes a deleted table
+     */
+    public static boolean isTableDeletedError(String error) {
+        if (error == null) {
+            return false;
+        }
+        String normalized = error.toLowerCase(Locale.ROOT);
+        return TABLE_DELETED_ERROR_MARKERS.stream().anyMatch(normalized::contains);
+    }
 
     public static MetricsConstants.MetadataUploadFailureReasons getMetadataExtractorFailureReason(
         Throwable ex,

--- a/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableMetadataUploaderService.java
+++ b/lakeview/src/main/java/ai/onehouse/metadata_extractor/TableMetadataUploaderService.java
@@ -362,6 +362,19 @@ public class TableMetadataUploaderService {
                         continue;
                       }
                       if (!StringUtils.isBlank(response.getError())) {
+                        // A deleted table is the control plane telling us there is nothing left to
+                        // upload — an expected outcome on a successful (HTTP 200) response, not a
+                        // failure. Counting it as one produced an ERROR log plus a
+                        // API_FAILURE_USER_ERROR increment per deleted table per cycle (ENG-45879).
+                        if (MetadataExtractorUtils.isTableDeletedError(response.getError())) {
+                          hudiMetadataExtractorMetrics.incrementTableSkippedCounter(
+                              MetricsConstants.TableSkipReasons.DELETED);
+                          log.info(
+                              "Skipping table {}: reported as deleted by the control plane ({})",
+                              table.getAbsoluteTableUri(),
+                              response.getError());
+                          continue;
+                        }
                         hudiMetadataExtractorMetrics.incrementTableMetadataProcessingFailureCounter(
                             MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR,
                             String.format("Error initialising table %s: %s", table, response.getError()));

--- a/lakeview/src/main/java/ai/onehouse/metrics/LakeViewExtractorMetrics.java
+++ b/lakeview/src/main/java/ai/onehouse/metrics/LakeViewExtractorMetrics.java
@@ -27,6 +27,8 @@ public class LakeViewExtractorMetrics {
   static final String EXTRACTOR_JOB_RUN_MODE_TAG_KEY = "extractor_job_run_mode";
   static final String METADATA_UPLOAD_FAILURE_REASON_TAG_KEY = "metadata_upload_failure_reason";
   static final String METADATA_DISCOVER_FAILURE_REASON_TAG_KEY = "metadata_discover_failure_reason";
+  // Why a table was intentionally skipped for a cycle (expected outcome, not a failure).
+  static final String TABLE_SKIP_REASON_TAG_KEY = "table_skip_reason";
   // The failing path from the discovery walk. Named discovery_path (not table_base_path) because
   // it is the prefix whose listing failed — which may be a table root or, when a Deny lands on a
   // parent prefix before the walk descends, a container of many tables.
@@ -48,6 +50,7 @@ public class LakeViewExtractorMetrics {
   static final String FAILED_OVERRIDE_CONFIG_COUNTER = METRICS_COMMON_PREFIX + "failed_override_config";
   static final String TABLE_METADATA_PROCESSING_FAILURE_COUNTER =
       METRICS_COMMON_PREFIX + "table_metadata_processing_failure";
+  static final String TABLE_SKIPPED_COUNTER = METRICS_COMMON_PREFIX + "table_skipped";
   static final String INCOMPLETE_COMMIT_INSTANTS_SKIPPED_COUNTER =
       METRICS_COMMON_PREFIX + "incomplete_commit_instants_skipped";
 
@@ -122,6 +125,18 @@ public class LakeViewExtractorMetrics {
     tags.add(Tag.of(METADATA_UPLOAD_FAILURE_REASON_TAG_KEY, metadataUploadFailureReasons.name()));
     metrics.increment(TABLE_METADATA_PROCESSING_FAILURE_COUNTER, tags);
     log.error("Table metadata processing failed with reason: {} - {}", metadataUploadFailureReasons.name(), failureReason);
+  }
+
+  /**
+   * Records that a table was intentionally skipped for this cycle — an expected outcome, not a
+   * failure. Deliberately separate from {@link #incrementTableMetadataProcessingFailureCounter}
+   * so the failure counter keeps meaning "something went wrong", and deliberately does not log:
+   * callers log at INFO with the table context they have.
+   */
+  public void incrementTableSkippedCounter(MetricsConstants.TableSkipReasons tableSkipReason) {
+    List<Tag> tags = getDefaultTags();
+    tags.add(Tag.of(TABLE_SKIP_REASON_TAG_KEY, tableSkipReason.name()));
+    metrics.increment(TABLE_SKIPPED_COUNTER, tags);
   }
 
   public void resetTableProcessedGauge() {

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/MetadataExtractorUtilsTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/MetadataExtractorUtilsTest.java
@@ -8,13 +8,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.concurrent.CompletionException;
 import java.util.stream.Stream;
 
 import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.getMetadataExtractorFailureReason;
+import static ai.onehouse.metadata_extractor.MetadataExtractorUtils.isTableDeletedError;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class MetadataExtractorUtilsTest {
@@ -44,5 +49,43 @@ class MetadataExtractorUtilsTest {
             Arguments.of(MetricsConstants.MetadataUploadFailureReasons.UNKNOWN,
                 MetricsConstants.MetadataUploadFailureReasons.ACCESS_DENIED,
                 new AccessDeniedException("")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        // Verbatim control-plane advisory observed in production (PD Q043G44USWZC7F).
+        "Table can be skipped as it is deleted",
+        // Same advisory as it reaches the metrics/log call site, wrapped with table context.
+        "Error initialising table Table(absoluteTableUri=s3://bucket/db/tbl/v1, databaseName=db, "
+            + "tableId=ca61e51d-9080-324f-b56c-765ffca993eb, tableVersion=6, tableFormat=HUDI): "
+            + "Table can be skipped as it is deleted",
+        // Case-insensitive.
+        "TABLE CAN BE SKIPPED AS IT IS DELETED",
+        // Tolerates a reworded prefix around the distinctive core.
+        "This table can be skipped as it is deleted",
+        "table is deleted",
+    })
+    void testIsTableDeletedErrorMatchesDeletedAdvisory(String error) {
+        assertTrue(isTableDeletedError(error));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        // Real failures must NOT be reclassified as a benign skip.
+        "API call failed with status code: 401 - Confirm that your API token is valid and has not expired.",
+        "API call failed with status code: 403 - Forbidden",
+        "Internal server error",
+        // Mentions deletion but is a genuine failure, not the skip advisory.
+        "Failed to delete table metadata",
+        "could not determine whether table was deleted",
+    })
+    void testIsTableDeletedErrorDoesNotMatchRealFailures(String error) {
+        assertFalse(isTableDeletedError(error));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void testIsTableDeletedErrorHandlesNullAndEmpty(String error) {
+        assertFalse(isTableDeletedError(error));
     }
 }

--- a/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableMetadataUploaderServiceTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metadata_extractor/TableMetadataUploaderServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -237,6 +238,93 @@ class TableMetadataUploaderServiceTest {
             FINAL_ARCHIVED_TIMELINE_CHECKPOINT_WITH_RESET_FIELDS,
             CommitTimelineType.COMMIT_TIMELINE_TYPE_ACTIVE))
         .thenReturn(CompletableFuture.completedFuture(FINAL_ACTIVE_TIMELINE_CHECKPOINT));
+  }
+
+  /**
+   * A table the control plane reports as deleted must be skipped quietly: counted on the
+   * table-skipped counter, never on the processing-failure counter, and never uploaded. Regression
+   * test for ENG-45879, where this benign advisory was classified as API_FAILURE_USER_ERROR and
+   * logged at ERROR once per deleted table per cycle.
+   */
+  @Test
+  void testUploadMetadataSkipsTableDeletedInControlPlane() {
+    setupInitialiseTableMetricsCheckpointErrorMocks(
+        TABLE_ID.toString(), S3_TABLE_URI, TABLE, "Table can be skipped as it is deleted");
+
+    // Nothing left to process is not a failure — the batch reports success.
+    Assertions.assertTrue(
+        tableMetadataUploaderService.uploadInstantsInTables(Collections.singleton(TABLE)).join());
+
+    verify(hudiMetadataExtractorMetrics)
+        .incrementTableSkippedCounter(MetricsConstants.TableSkipReasons.DELETED);
+    verify(hudiMetadataExtractorMetrics, never())
+        .incrementTableMetadataProcessingFailureCounter(
+            any(MetricsConstants.MetadataUploadFailureReasons.class), anyString());
+    // The table must not be uploaded after being skipped.
+    verify(timelineCommitInstantsUploader, never())
+        .batchUploadWithCheckpoint(any(), any(), any(), any());
+  }
+
+  /**
+   * A genuine per-table initialise error must still be counted as a processing failure — the
+   * ENG-45879 fix must not swallow real errors.
+   */
+  @Test
+  void testUploadMetadataCountsRealInitialiseErrorAsFailure() {
+    setupInitialiseTableMetricsCheckpointErrorMocks(
+        TABLE_ID.toString(), S3_TABLE_URI, TABLE, "Internal server error");
+
+    tableMetadataUploaderService.uploadInstantsInTables(Collections.singleton(TABLE)).join();
+
+    verify(hudiMetadataExtractorMetrics)
+        .incrementTableMetadataProcessingFailureCounter(
+            eq(MetricsConstants.MetadataUploadFailureReasons.API_FAILURE_USER_ERROR), anyString());
+    verify(hudiMetadataExtractorMetrics, never())
+        .incrementTableSkippedCounter(any(MetricsConstants.TableSkipReasons.class));
+  }
+
+  /**
+   * Sets up a newly-discovered table whose initialize-tables response carries a per-table {@code
+   * error} on an otherwise successful response.
+   */
+  private void setupInitialiseTableMetricsCheckpointErrorMocks(
+      String tableId, String tableBasePath, Table table, String perTableError) {
+    when(onehouseApiClient.getTableMetricsCheckpoints(Collections.singletonList(tableId)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                GetTableMetricsCheckpointResponse.builder()
+                    .checkpoints(Collections.emptyList())
+                    .build()));
+    when(hoodiePropertiesReader.readHoodieProperties(
+            String.format("%s%s/%s", tableBasePath, HOODIE_FOLDER_NAME, HOODIE_PROPERTIES_FILE)))
+        .thenReturn(CompletableFuture.completedFuture(PARSED_HUDI_PROPERTIES));
+
+    InitializeTableMetricsCheckpointRequest expectedRequest =
+        InitializeTableMetricsCheckpointRequest.builder()
+            .tables(
+                Collections.singletonList(
+                    InitializeTableMetricsCheckpointRequest
+                        .InitializeSingleTableMetricsCheckpointRequest.builder()
+                        .tableId(tableId)
+                        .tableName(PARSED_HUDI_PROPERTIES.getTableName())
+                        .tableType(PARSED_HUDI_PROPERTIES.getTableType())
+                        .databaseName(table.getDatabaseName())
+                        .lakeName(table.getLakeName())
+                        .tableBasePath(tableBasePath)
+                        .build()))
+            .build();
+    when(onehouseApiClient.initializeTableMetricsCheckpoint(expectedRequest))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                InitializeTableMetricsCheckpointResponse.builder()
+                    .response(
+                        Collections.singletonList(
+                            InitializeTableMetricsCheckpointResponse
+                                .InitializeSingleTableMetricsCheckpointResponse.builder()
+                                .tableId(tableId)
+                                .error(perTableError)
+                                .build()))
+                    .build()));
   }
 
   @Test

--- a/lakeview/src/test/java/ai/onehouse/metrics/LakeViewExtractorMetricsTest.java
+++ b/lakeview/src/test/java/ai/onehouse/metrics/LakeViewExtractorMetricsTest.java
@@ -1,6 +1,9 @@
 package ai.onehouse.metrics;
 
 import static ai.onehouse.metrics.LakeViewExtractorMetrics.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -84,6 +87,18 @@ class LakeViewExtractorMetricsTest {
     tags.add(Tag.of(METADATA_DISCOVER_FAILURE_REASON_TAG_KEY, reason.name()));
     tags.add(Tag.of(DISCOVERY_PATH_TAG_KEY, discoveryPath));
     verify(metrics).increment(TABLE_DISCOVERY_FAILURE_COUNTER, tags);
+  }
+
+  @ParameterizedTest
+  @EnumSource(MetricsConstants.TableSkipReasons.class)
+  void testIncrementTableSkippedCounter(MetricsConstants.TableSkipReasons reason) {
+    hudiMetadataExtractorMetrics.incrementTableSkippedCounter(reason);
+    List<Tag> tags = getDefaultTags();
+    tags.add(Tag.of(TABLE_SKIP_REASON_TAG_KEY, reason.name()));
+    verify(metrics).increment(TABLE_SKIPPED_COUNTER, tags);
+    // A skip is not a failure — it must never touch the processing-failure counter.
+    verify(metrics, never())
+        .increment(eq(TABLE_METADATA_PROCESSING_FAILURE_COUNTER), anyList());
   }
 
 


### PR DESCRIPTION
## Summary

When a table is deleted control-plane side, `POST /v1/community/initialize-tables` returns **HTTP 200** with a per-table `error` string:

```
Table can be skipped as it is deleted
```

That is an advisory — "there is nothing to upload for this table" — not a failure. But the call site treated *any* non-blank per-table `error` as `API_FAILURE_USER_ERROR` and logged at `ERROR`, twice per table per cycle (once at the call site, once inside `incrementTableMetadataProcessingFailureCounter`).

Found while investigating PD `Q043G44USWZC7F`: an org with **198 of 199 tables deleted** produced **9,528 counted "failures"** in ~9.5 hours on a completely healthy extractor — `Running`, `1/1`, `restartCount: 0`, `lakeView_table_discovery_success_total` incrementing +12/hr throughout. Nothing was wrong with the extractor, the network, or the credentials.

Two concrete harms:

1. **Misdirected triage.** `API_FAILURE_USER_ERROR` reads as connectivity or credentials — the same reason code *is* used for real `401`/`403`s from `OnehouseApiClient.emmitApiErrorMetric`. The natural first move is to go chase an expired API token, when in fact no HTTP call failed.
2. **The metric isn't actionable.** `lakeView_table_metadata_processing_failure_total{metadata_upload_failure_reason="API_FAILURE_USER_ERROR"}` could not distinguish "the customer deleted their tables" (no action) from "our API is rejecting us" (page someone).

## Changes

| Before | After |
|---|---|
| `..._processing_failure{reason="API_FAILURE_USER_ERROR"}` | `lakeView_table_skipped{table_skip_reason="DELETED"}` |
| `ERROR` ×2 per table per cycle | `INFO` ×1 |

- **`MetricsConstants`** — new `TableSkipReasons { DELETED }`, deliberately **separate** from `MetadataUploadFailureReasons` so the failure counter keeps meaning "something went wrong".
- **`MetadataExtractorUtils.isTableDeletedError(String)`** — classifies the advisory, placed alongside the existing `getMetadataExtractorFailureReason` helper.
- **`LakeViewExtractorMetrics.incrementTableSkippedCounter(...)`** — new `lakeView_table_skipped` counter tagged `table_skip_reason`. Deliberately does *not* log (unlike the failure method, which logs internally — that's the source of the second ERROR line); the caller logs at INFO with table context.
- **`TableMetadataUploaderService`** — branch on the classification before the failure path.

Kept a counter rather than going silent: `lakeView_table_skipped{table_skip_reason="DELETED"}` would have answered the whole investigation in one query.

## Technical details

**Real errors are unaffected.** Only the deleted-advisory is reclassified; every other per-table `error` still increments `API_FAILURE_USER_ERROR` and logs at `ERROR`. There is a regression test asserting exactly that.

**Behavior otherwise unchanged.** The skip branch `continue`s exactly as the old error branch did, so control flow and the batch return value are untouched.

**Known limitation — matched on message text.** `InitializeTableMetricsCheckpointResponse.InitializeSingleTableMetricsCheckpointResponse` carries only a free-text `error` field; there is no structured error/status code to switch on. A control-plane reword could silently break the match, so I used two distinctive markers rather than the full sentence and documented the constraint in the javadoc. **The durable fix is control-plane side**: a structured `errorCode` / `skipReason` on that response, at which point `isTableDeletedError` becomes a code check. Happy to follow up if the API team wants to add one.

## Testing

`./gradlew :lakeview:test` — **42 tests across the three affected classes, all passing**:

- `MetadataExtractorUtilsTest` (16) — the verbatim production string; the wrapped form as it reaches the call site; case-insensitivity; a reworded prefix; plus **negative cases** asserting `401`/`403`/`Internal server error` and deletion-adjacent-but-real failures are *not* reclassified; and null/empty.
- `TableMetadataUploaderServiceTest` (13) — two new: a deleted table increments the skip counter, never the failure counter, and is never uploaded; a real error still counts as `API_FAILURE_USER_ERROR` and never as a skip.
- `LakeViewExtractorMetricsTest` (13) — the new counter's tag set, and that it never touches the failure counter.

`./gradlew spotlessCheck` passes.

⚠️ **Pre-existing unrelated test failure on `main`:** `AsyncHttpClientWithRetryTest.testMakeRequestWithRetryIOException` fails (1 of 322). Confirmed pre-existing by stashing this branch's changes and re-running it against clean `origin/main` — it fails identically there. Not introduced here, but it will make CI's `clean check` red until it's fixed separately.

## Noted, not changed

A real per-table init error still lets the batch report **success** — the error path `continue`s without adding a future, and `allMatch` on an empty stream returns `true`. That's correct for the deleted case (nothing to do), but arguably wrong for real errors. Left alone because fixing it changes behavior beyond classification; worth its own ticket.

## Related ticket

- **ENG-45879** — this bug
- **ENG-45878** — RCA of PD `Q043G44USWZC7F` that surfaced it
- **knowledge-base#241** — runbook branch so on-call doesn't misread the reason code before this ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)